### PR TITLE
Update opaque and implement it without DB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -729,6 +729,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-mac"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25fab6889090c8133f3deb8f73ba3c65a7f456f66436fc012a1b1e272b1e103e"
+dependencies = [
+ "generic-array",
+ "subtle",
+]
+
+[[package]]
+name = "ct-codecs"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3b7eb4404b8195a9abb6356f4ac07d8ba267045c8d6d220ac4dc992e6cc75df"
+
+[[package]]
 name = "curve25519-dalek"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -737,6 +753,7 @@ dependencies = [
  "byteorder",
  "digest",
  "rand_core 0.5.1",
+ "serde",
  "subtle",
  "zeroize",
 ]
@@ -1056,6 +1073,7 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 dependencies = [
+ "serde",
  "typenum",
  "version_check",
 ]
@@ -1210,12 +1228,12 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hkdf"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51ab2f639c231793c5f6114bdb9bbe50a7dbbfcd7c7c6bd8475dec2d991e964f"
+checksum = "01706d578d5c281058480e673ae4086a9f4710d8df1ad80a5b03e39ece5f886b"
 dependencies = [
  "digest",
- "hmac",
+ "hmac 0.11.0",
 ]
 
 [[package]]
@@ -1224,7 +1242,17 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
 dependencies = [
- "crypto-mac",
+ "crypto-mac 0.10.0",
+ "digest",
+]
+
+[[package]]
+name = "hmac"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
+dependencies = [
+ "crypto-mac 0.11.0",
  "digest",
 ]
 
@@ -1324,9 +1352,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86e46349d67dc03bdbdb28da0337a355a53ca1d5156452722c36fe21d0e6389b"
 dependencies = [
  "base64",
- "crypto-mac",
+ "crypto-mac 0.10.0",
  "digest",
- "hmac",
+ "hmac 0.10.1",
  "serde",
  "serde_json",
  "sha2",
@@ -1419,6 +1447,8 @@ dependencies = [
  "actix-web-httpauth",
  "anyhow",
  "async-trait",
+ "base64",
+ "bincode",
  "chrono",
  "clap",
  "cron",
@@ -1426,7 +1456,7 @@ dependencies = [
  "figment",
  "futures",
  "futures-util",
- "hmac",
+ "hmac 0.10.1",
  "http",
  "jwt",
  "ldap3_server",
@@ -1434,6 +1464,7 @@ dependencies = [
  "log",
  "mockall",
  "opaque-ke",
+ "orion",
  "rand 0.8.3",
  "sea-query",
  "serde",
@@ -1804,8 +1835,8 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "opaque-ke"
-version = "0.5.1-pre.1"
-source = "git+https://github.com/novifinancial/opaque-ke?rev=98f1821897cd2800e5bffb2a70541056145e99cc#98f1821897cd2800e5bffb2a70541056145e99cc"
+version = "0.6.0-pre.1"
+source = "git+https://github.com/novifinancial/opaque-ke?rev=eb59676a940b15f77871aefe1e46d7b5bf85f40a#eb59676a940b15f77871aefe1e46d7b5bf85f40a"
 dependencies = [
  "base64",
  "curve25519-dalek",
@@ -1814,7 +1845,7 @@ dependencies = [
  "generic-array",
  "generic-bytes",
  "hkdf",
- "hmac",
+ "hmac 0.11.0",
  "rand 0.8.3",
  "serde",
  "subtle",
@@ -1869,6 +1900,18 @@ dependencies = [
  "pin-project",
  "rand 0.8.3",
  "thiserror",
+]
+
+[[package]]
+name = "orion"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "118f94b4ca56d1eb99466a26a216b87fad822a51af8b308264c88a9337eb0a15"
+dependencies = [
+ "ct-codecs",
+ "getrandom 0.2.3",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2525,7 +2568,7 @@ dependencies = [
  "generic-array",
  "hashlink",
  "hex",
- "hmac",
+ "hmac 0.10.1",
  "itoa",
  "libc",
  "libsqlite3-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ actix-service = "2.0.0"
 actix-web = "4.0.0-beta.3"
 anyhow = "*"
 async-trait = "0.1"
+base64 = "0.13"
+bincode = "1.3"
 chrono = { version = "*", features = [ "serde" ]}
 clap = "3.0.0-beta.2"
 cron = "*"
@@ -28,6 +30,7 @@ jwt = "0.13"
 ldap3_server = "*"
 lldap_model = { path = "model" }
 log = "*"
+orion = "0.16"
 serde = "*"
 serde_json = "1"
 sha2 = "0.9"
@@ -45,7 +48,7 @@ rand = { version = "0.8", features = ["small_rng", "getrandom"] }
 # TODO: update to 0.6 when out.
 [dependencies.opaque-ke]
 git = "https://github.com/novifinancial/opaque-ke"
-rev = "98f1821897cd2800e5bffb2a70541056145e99cc"
+rev = "eb59676a940b15f77871aefe1e46d7b5bf85f40a"
 
 [dependencies.sqlx]
 version = "0.5.1"

--- a/app/src/login.rs
+++ b/app/src/login.rs
@@ -92,7 +92,7 @@ impl LoginForm {
                     Ok(l) => l,
                 };
                 let req = login::ClientLoginFinishRequest {
-                    login_key: res.login_key,
+                    server_data: res.server_data,
                     credential_finalization: login_finish.message,
                 };
                 self.call_backend(

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -23,7 +23,7 @@ thiserror = "*"
 # TODO: update to 0.6 when out.
 [dependencies.opaque-ke]
 git = "https://github.com/novifinancial/opaque-ke"
-rev = "98f1821897cd2800e5bffb2a70541056145e99cc"
+rev = "eb59676a940b15f77871aefe1e46d7b5bf85f40a"
 
 [dependencies.chrono]
 version = "*"

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -15,6 +15,12 @@ pub mod login {
     use super::*;
 
     #[derive(Serialize, Deserialize, Clone)]
+    pub struct ServerData {
+        pub username: String,
+        pub server_login: opaque::server::login::ServerLogin,
+    }
+
+    #[derive(Serialize, Deserialize, Clone)]
     pub struct ClientLoginStartRequest {
         pub username: String,
         pub login_start_request: opaque::server::login::CredentialRequest,
@@ -22,15 +28,15 @@ pub mod login {
 
     #[derive(Serialize, Deserialize, Clone)]
     pub struct ServerLoginStartResponse {
-        /// A randomly-generated temporary key that corresponds to this login attempt.
-        pub login_key: String,
+        /// Base64, encrypted ServerData to be passed back to the server.
+        pub server_data: String,
         pub credential_response: opaque::client::login::CredentialResponse,
     }
 
     #[derive(Serialize, Deserialize, Clone)]
     pub struct ClientLoginFinishRequest {
-        /// The key returned by the server in the previous step.
-        pub login_key: String,
+        /// Encrypted ServerData from the previous step.
+        pub server_data: String,
         pub credential_finalization: opaque::client::login::CredentialFinalization,
     }
 }
@@ -40,6 +46,11 @@ pub mod registration {
     use super::*;
 
     #[derive(Serialize, Deserialize, Clone)]
+    pub struct ServerData {
+        pub username: String,
+    }
+
+    #[derive(Serialize, Deserialize, Clone)]
     pub struct ClientRegistrationStartRequest {
         pub username: String,
         pub registration_start_request: opaque::server::registration::RegistrationRequest,
@@ -47,15 +58,15 @@ pub mod registration {
 
     #[derive(Serialize, Deserialize, Clone)]
     pub struct ServerRegistrationStartResponse {
-        /// A randomly-generated temporary key that corresponds to this registration attempt.
-        pub registration_key: String,
+        /// Base64, encrypted ServerData to be passed back to the server.
+        pub server_data: String,
         pub registration_response: opaque::client::registration::RegistrationResponse,
     }
 
     #[derive(Serialize, Deserialize, Clone)]
     pub struct ClientRegistrationFinishRequest {
-        /// The key returned by the server in the previous step.
-        pub registration_key: String,
+        /// Encrypted ServerData from the previous step.
+        pub server_data: String,
         pub registration_upload: opaque::server::registration::RegistrationUpload,
     }
 }

--- a/src/domain/error.rs
+++ b/src/domain/error.rs
@@ -9,6 +9,12 @@ pub enum DomainError {
     DatabaseError(#[from] sqlx::Error),
     #[error("Authentication protocol error for `{0}`")]
     AuthenticationProtocolError(#[from] lldap_model::opaque::AuthenticationError),
+    #[error("Unknown crypto error: `{0}`")]
+    UnknownCryptoError(#[from] orion::errors::UnknownCryptoError),
+    #[error("Binary serialization error: `{0}`")]
+    BinarySerializationError(#[from] bincode::Error),
+    #[error("Invalid base64: `{0}`")]
+    Base64DecodeError(#[from] base64::DecodeError),
     #[error("Internal error: `{0}`")]
     InternalError(String),
 }

--- a/src/domain/sql_tables.rs
+++ b/src/domain/sql_tables.rs
@@ -34,27 +34,6 @@ pub enum Memberships {
     GroupId,
 }
 
-/// Contains the temporary data that needs to be kept between the first and second message when
-/// logging in with the OPAQUE protocol.
-#[derive(Iden)]
-pub enum LoginAttempts {
-    Table,
-    RandomId,
-    UserId,
-    ServerLoginData,
-    Timestamp,
-}
-
-/// Same for registration.
-#[derive(Iden)]
-pub enum RegistrationAttempts {
-    Table,
-    RandomId,
-    UserId,
-    ServerRegistrationData,
-    Timestamp,
-}
-
 pub async fn init_table(pool: &Pool) -> sqlx::Result<()> {
     // SQLite needs this pragma to be turned on. Other DB might not understand this, so ignore the
     // error.
@@ -127,80 +106,6 @@ pub async fn init_table(pool: &Pool) -> sqlx::Result<()> {
                     .name("MembershipGroupForeignKey")
                     .table(Memberships::Table, Groups::Table)
                     .col(Memberships::GroupId, Groups::GroupId)
-                    .on_delete(ForeignKeyAction::Cascade)
-                    .on_update(ForeignKeyAction::Cascade),
-            )
-            .to_string(DbQueryBuilder {}),
-    )
-    .execute(pool)
-    .await?;
-
-    sqlx::query(
-        &Table::create()
-            .table(LoginAttempts::Table)
-            .if_not_exists()
-            .col(
-                ColumnDef::new(LoginAttempts::RandomId)
-                    .string_len(32)
-                    .primary_key(),
-            )
-            .col(
-                ColumnDef::new(LoginAttempts::UserId)
-                    .string_len(255)
-                    .not_null(),
-            )
-            .col(
-                ColumnDef::new(LoginAttempts::ServerLoginData)
-                    .binary()
-                    .not_null(),
-            )
-            .col(
-                ColumnDef::new(LoginAttempts::Timestamp)
-                    .date_time()
-                    .not_null(),
-            )
-            .foreign_key(
-                ForeignKey::create()
-                    .name("LoginAttemptsUserIdForeignKey")
-                    .table(LoginAttempts::Table, Users::Table)
-                    .col(LoginAttempts::UserId, Users::UserId)
-                    .on_delete(ForeignKeyAction::Cascade)
-                    .on_update(ForeignKeyAction::Cascade),
-            )
-            .to_string(DbQueryBuilder {}),
-    )
-    .execute(pool)
-    .await?;
-
-    sqlx::query(
-        &Table::create()
-            .table(RegistrationAttempts::Table)
-            .if_not_exists()
-            .col(
-                ColumnDef::new(RegistrationAttempts::RandomId)
-                    .string_len(32)
-                    .primary_key(),
-            )
-            .col(
-                ColumnDef::new(RegistrationAttempts::UserId)
-                    .string_len(255)
-                    .not_null(),
-            )
-            .col(
-                ColumnDef::new(RegistrationAttempts::ServerRegistrationData)
-                    .binary()
-                    .not_null(),
-            )
-            .col(
-                ColumnDef::new(RegistrationAttempts::Timestamp)
-                    .date_time()
-                    .not_null(),
-            )
-            .foreign_key(
-                ForeignKey::create()
-                    .name("RegistrationAttemptsUserIdForeignKey")
-                    .table(RegistrationAttempts::Table, Users::Table)
-                    .col(RegistrationAttempts::UserId, Users::UserId)
                     .on_delete(ForeignKeyAction::Cascade)
                     .on_update(ForeignKeyAction::Cascade),
             )

--- a/src/infra/db_cleaner.rs
+++ b/src/infra/db_cleaner.rs
@@ -1,5 +1,5 @@
 use crate::{
-    domain::sql_tables::{DbQueryBuilder, LoginAttempts, Pool, RegistrationAttempts},
+    domain::sql_tables::{DbQueryBuilder, Pool},
     infra::jwt_sql_tables::{JwtRefreshStorage, JwtStorage},
 };
 use actix::prelude::*;
@@ -69,34 +69,6 @@ impl Scheduler {
         .await
         {
             log::error!("DB error while cleaning up JWT storage: {}", e);
-        };
-        if let Err(e) = sqlx::query(
-            &Query::delete()
-                .from_table(LoginAttempts::Table)
-                .and_where(
-                    Expr::col(LoginAttempts::Timestamp)
-                        .lt(Local::now().naive_utc() - chrono::Duration::minutes(5)),
-                )
-                .to_string(DbQueryBuilder {}),
-        )
-        .execute(&sql_pool)
-        .await
-        {
-            log::error!("DB error while cleaning up login attempts: {}", e);
-        };
-        if let Err(e) = sqlx::query(
-            &Query::delete()
-                .from_table(RegistrationAttempts::Table)
-                .and_where(
-                    Expr::col(RegistrationAttempts::Timestamp)
-                        .lt(Local::now().naive_utc() - chrono::Duration::minutes(5)),
-                )
-                .to_string(DbQueryBuilder {}),
-        )
-        .execute(&sql_pool)
-        .await
-        {
-            log::error!("DB error while cleaning up registration attempts: {}", e);
         };
         log::info!("DB cleaned!");
     }

--- a/src/infra/tcp_server.rs
+++ b/src/infra/tcp_server.rs
@@ -32,8 +32,11 @@ pub(crate) fn error_to_http_response(error: DomainError) -> HttpResponse {
         DomainError::AuthenticationError(_) | DomainError::AuthenticationProtocolError(_) => {
             HttpResponse::Unauthorized()
         }
-        DomainError::DatabaseError(_) | DomainError::InternalError(_) => {
-            HttpResponse::InternalServerError()
+        DomainError::DatabaseError(_)
+        | DomainError::InternalError(_)
+        | DomainError::UnknownCryptoError(_) => HttpResponse::InternalServerError(),
+        DomainError::Base64DecodeError(_) | DomainError::BinarySerializationError(_) => {
+            HttpResponse::BadRequest()
         }
     }
     .body(error.to_string())


### PR DESCRIPTION
opaque_ke changed their interface, update to the latest.

State needs to be kept from one step to the next during the login/registration. Rather than storing it in the database, send it (encrypted) to the client and back.