### PR TITLE
Implement a GraphQL endpoint and use it in the client

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,6 +21,11 @@ jobs:
         run: cargo build --verbose --workspace
       - name: Run tests
         run: cargo test --verbose --workspace
+      - name: Generate GraphQL schema
+        run: cargo run -- export_graphql_schema -o generated_schema.graphql
+      - name: Check schema
+        run: diff schema.graphql generated_schema.graphql
+
 
   clippy:
     name: cargo clippy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,6 +290,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "addr2line"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61f2b7f93d2c7d2b08263acaa4a363b3e276806c68af6134c44f523bf1aacd"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -428,6 +437,21 @@ name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
+name = "backtrace"
+version = "0.3.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a905d892734eea339e896738c14b9afce22b5318f64b951e70bf3844419b01"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "base-x"
@@ -962,6 +986,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "failure"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
+dependencies = [
+ "backtrace",
+ "failure_derive",
+]
+
+[[package]]
+name = "failure_derive"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "figment"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1189,6 +1235,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
+
+[[package]]
 name = "gloo"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1243,6 +1295,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "graphql-introspection-query"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f2a4732cf5140bd6c082434494f785a19cfb566ab07d1382c3671f5812fed6d"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "graphql-parser"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5613c31f18676f164112732202124f373bb2103ff017b3b85ca954ea6a66ada"
+dependencies = [
+ "combine",
+ "failure",
+]
+
+[[package]]
 name = "graphql-parser"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1250,6 +1321,45 @@ checksum = "d1abd4ce5247dfc04a03ccde70f87a048458c9356c7e41d21ad8c407b3dde6f2"
 dependencies = [
  "combine",
  "thiserror",
+]
+
+[[package]]
+name = "graphql_client"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9b58571cfc3cc42c3e8ff44fc6cfbb6c0dea17ed22d20f9d8f1efc4e8209a3f"
+dependencies = [
+ "graphql_query_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "graphql_client_codegen"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4bf9cd823359d74ad3d3ecf1afd4a975f4ff2f891cdf9a66744606daf52de8c"
+dependencies = [
+ "graphql-introspection-query",
+ "graphql-parser 0.2.3",
+ "heck",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn",
+]
+
+[[package]]
+name = "graphql_query_derive"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e56b093bfda71de1da99758b036f4cc811fd2511c8a76f75680e9ffbd2bb4251"
+dependencies = [
+ "graphql_client_codegen",
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -1445,7 +1555,7 @@ dependencies = [
  "fnv",
  "futures",
  "futures-enum",
- "graphql-parser",
+ "graphql-parser 0.3.0",
  "indexmap",
  "juniper_codegen",
  "serde",
@@ -1637,6 +1747,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "graphql_client",
  "http",
  "jwt",
  "lldap_model",
@@ -1968,6 +2079,15 @@ checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c55827317fb4c08822499848a14237d2874d6f139828893017237e7ab93eb386"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2429,6 +2549,12 @@ dependencies = [
  "constant_time_eq",
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "rustc_version"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,6 +239,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-web-actors"
+version = "4.0.0-beta.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7db5c2c78a2606e6634abee4973a4924221cfab66e48f23844256e4fb8ce0f42"
+dependencies = [
+ "actix",
+ "actix-codec",
+ "actix-http",
+ "actix-web",
+ "bytes",
+ "bytestring",
+ "futures-core",
+ "pin-project",
+ "tokio",
+]
+
+[[package]]
 name = "actix-web-codegen"
 version = "0.5.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,6 +364,12 @@ name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
+name = "ascii"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
 
 [[package]]
 name = "askama_escape"
@@ -492,6 +515,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "bson"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "903a4f4c7aa97921f1703acac1fd524e9e082b3228edd34dde07758c0c92c672"
+dependencies = [
+ "base64",
+ "chrono",
+ "hex",
+ "lazy_static",
+ "linked-hash-map",
+ "rand 0.7.3",
+ "serde",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
 name = "build_const"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -595,6 +635,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "combine"
+version = "3.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3da6baa321ec19e1cc41d31bf599f00c783d0517095cdaf0332e3fe8d20680"
+dependencies = [
+ "ascii",
+ "byteorder",
+ "either",
+ "memchr",
+ "unreachable",
 ]
 
 [[package]]
@@ -839,6 +892,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_utils"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "532b4c15dccee12c7044f1fcad956e98410860b22231e44a3b827464797ca7bf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1007,6 +1071,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0402f765d8a89a26043b889b26ce3c4679d268fa6bb22cd7c6aad98340e179d1"
 
 [[package]]
+name = "futures-enum"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3422d14de7903a52e9dbc10ae05a7e14445ec61890100e098754e120b2bd7b1e"
+dependencies = [
+ "derive_utils",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-executor"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1168,6 +1243,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "graphql-parser"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1abd4ce5247dfc04a03ccde70f87a048458c9356c7e41d21ad8c407b3dde6f2"
+dependencies = [
+ "combine",
+ "thiserror",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1306,6 +1391,7 @@ checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
 dependencies = [
  "autocfg 1.0.1",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -1345,6 +1431,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "juniper"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "637ffa8a8d8a05aed3331449e311f145864adcd82442d82e54d0522decb7cecf"
+dependencies = [
+ "async-trait",
+ "bson",
+ "chrono",
+ "fnv",
+ "futures",
+ "futures-enum",
+ "graphql-parser",
+ "indexmap",
+ "juniper_codegen",
+ "serde",
+ "smartstring",
+ "static_assertions",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "juniper_actix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc44af18ae1f551076171e24eb453c52132a19c219d1f1a1c3068ab363b946b5"
+dependencies = [
+ "actix",
+ "actix-http",
+ "actix-web",
+ "actix-web-actors",
+ "anyhow",
+ "futures",
+ "http",
+ "juniper",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "juniper_codegen"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a040e09482a45e77dd2dafa0d9d2651d17faf0ac674da0c93eabc3075ee24997"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1436,6 +1575,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
+
+[[package]]
 name = "lldap"
 version = "0.1.0"
 dependencies = [
@@ -1460,6 +1605,8 @@ dependencies = [
  "futures-util",
  "hmac 0.10.1",
  "http",
+ "juniper",
+ "juniper_actix",
  "jwt",
  "ldap3_server",
  "lldap_model",
@@ -2400,6 +2547,7 @@ version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
 dependencies = [
+ "indexmap",
  "itoa",
  "ryu",
  "serde",
@@ -2489,6 +2637,15 @@ name = "smallvec"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
+
+[[package]]
+name = "smartstring"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31aa6a31c0c2b21327ce875f7e8952322acfcfd0c27569a6e18a647281352c9b"
+dependencies = [
+ "static_assertions",
+]
 
 [[package]]
 name = "socket2"
@@ -3098,6 +3255,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
+name = "unreachable"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
+dependencies = [
+ "void",
+]
+
+[[package]]
 name = "url"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3135,6 +3301,12 @@ name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,8 @@ tracing-actix-web = "0.4.0-beta.7"
 tracing-log = "*"
 tracing-subscriber = "*"
 rand = { version = "0.8", features = ["small_rng", "getrandom"] }
+juniper_actix = "0.4.0"
+juniper = "0.15.6"
 
 # TODO: update to 0.6 when out.
 [dependencies.opaque-ke]

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -15,6 +15,7 @@ serde_json = "1"
 wasm-bindgen = "0.2"
 yew = "0.18"
 yew-router = "0.15"
+graphql_client = "0.10.0"
 
 [dependencies.web-sys]
 version = "0.3"

--- a/app/queries/list_users.graphql
+++ b/app/queries/list_users.graphql
@@ -2,8 +2,9 @@ query ListUsersQuery($filters: RequestFilter) {
   users(filters: $filters) {
     id
     email
-    groups {
-      id
-    }
+    displayName
+    firstName
+    lastName
+    creationDate
   }
 }

--- a/app/queries/list_users.graphql
+++ b/app/queries/list_users.graphql
@@ -1,0 +1,9 @@
+query ListUsersQuery($filters: RequestFilter) {
+  users(filters: $filters) {
+    id
+    email
+    groups {
+      id
+    }
+  }
+}

--- a/app/src/create_user.rs
+++ b/app/src/create_user.rs
@@ -1,5 +1,5 @@
 use crate::api::HostService;
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use lldap_model::*;
 use yew::prelude::*;
 use yew::services::{fetch::FetchTask, ConsoleService};
@@ -48,7 +48,7 @@ impl CreateUserForm {
                 };
                 self._task = Some(
                     HostService::create_user(req, self.link.callback(Msg::CreateUserResponse))
-                        .map_err(|e| anyhow!("Error trying to create user: {}", e))?,
+                        .context("Error trying to create user")?,
                 );
             }
             Msg::CreateUserResponse(r) => {
@@ -73,7 +73,7 @@ impl CreateUserForm {
                             req,
                             self.link.callback(Msg::RegistrationStartResponse),
                         )
-                        .map_err(|e| anyhow!("Error trying to create user: {}", e))?,
+                        .context("Error trying to create user")?,
                     );
                 } else {
                     self.update(Msg::SuccessfulCreation);
@@ -97,7 +97,7 @@ impl CreateUserForm {
                         req,
                         self.link.callback(Msg::RegistrationFinishResponse),
                     )
-                    .map_err(|e| anyhow!("Error trying to register user: {}", e))?,
+                    .context("Error trying to register user")?,
                 );
             }
             Msg::RegistrationFinishResponse(response) => {

--- a/app/src/graphql.rs
+++ b/app/src/graphql.rs
@@ -1,0 +1,1 @@
+pub type DateTimeUtc = chrono::DateTime<chrono::Utc>;

--- a/app/src/graphql_api.rs
+++ b/app/src/graphql_api.rs
@@ -1,0 +1,8 @@
+use graphql_client::GraphQLQuery;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "../schema.graphql",
+    query_path = "queries/list_users.graphql"
+)]
+pub struct ListUsersQuery;

--- a/app/src/graphql_api.rs
+++ b/app/src/graphql_api.rs
@@ -1,8 +1,0 @@
-use graphql_client::GraphQLQuery;
-
-#[derive(GraphQLQuery)]
-#[graphql(
-    schema_path = "../schema.graphql",
-    query_path = "queries/list_users.graphql"
-)]
-pub struct ListUsersQuery;

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -4,6 +4,7 @@ mod api;
 mod app;
 mod cookies;
 mod create_user;
+mod graphql_api;
 mod login;
 mod logout;
 mod user_details;

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -4,6 +4,7 @@ mod api;
 mod app;
 mod cookies;
 mod create_user;
+mod graphql;
 mod login;
 mod logout;
 mod user_details;

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -4,7 +4,6 @@ mod api;
 mod app;
 mod cookies;
 mod create_user;
-mod graphql_api;
 mod login;
 mod logout;
 mod user_details;

--- a/app/src/login.rs
+++ b/app/src/login.rs
@@ -1,5 +1,5 @@
 use crate::api::HostService;
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use lldap_model::*;
 use wasm_bindgen::JsCast;
 use yew::prelude::*;
@@ -61,9 +61,8 @@ impl LoginForm {
                 let password = get_form_field("password")
                     .ok_or_else(|| anyhow!("Could not get password from form"))?;
                 let mut rng = rand::rngs::OsRng;
-                let login_start_request =
-                    opaque::client::login::start_login(&password, &mut rng)
-                        .map_err(|e| anyhow!("Could not initialize login: {}", e))?;
+                let login_start_request = opaque::client::login::start_login(&password, &mut rng)
+                    .context("Could not initialize login")?;
                 self.login_start = Some(login_start_request.state);
                 let req = login::ClientLoginStartRequest {
                     username,

--- a/app/src/user_table.rs
+++ b/app/src/user_table.rs
@@ -10,7 +10,7 @@ use yew::services::{fetch::FetchTask, ConsoleService};
     schema_path = "../schema.graphql",
     query_path = "queries/list_users.graphql",
     response_derives = "Debug",
-    custom_scalars_module = "chrono"
+    custom_scalars_module = "crate::graphql"
 )]
 pub struct ListUsersQuery;
 
@@ -89,7 +89,7 @@ impl Component for UserTable {
                                 <td>{&u.display_name.as_ref().unwrap_or(&String::new())}</td>
                                 <td>{&u.first_name.as_ref().unwrap_or(&String::new())}</td>
                                 <td>{&u.last_name.as_ref().unwrap_or(&String::new())}</td>
-                                <td>{&u.creation_date}</td>
+                                <td>{&u.creation_date.with_timezone(&chrono::Local)}</td>
                             </tr>
                         }
                     })

--- a/app/src/user_table.rs
+++ b/app/src/user_table.rs
@@ -24,17 +24,16 @@ pub enum Msg {
 
 impl UserTable {
     fn get_users(&mut self, req: Option<RequestFilter>) {
-        match HostService::graphql_query::<ListUsersQuery>(
+        self._task = HostService::graphql_query::<ListUsersQuery>(
             list_users_query::Variables { filters: req },
             self.link.callback(Msg::ListUsersResponse),
-            "",
-        ) {
-            Ok(task) => self._task = Some(task),
-            Err(e) => {
-                self._task = None;
-                ConsoleService::log(format!("Error trying to fetch users: {}", e).as_str())
-            }
-        };
+            "Error trying to fetch users",
+        )
+        .map_err(|e| {
+            ConsoleService::log(&e.to_string());
+            e
+        })
+        .ok();
     }
 }
 

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -100,7 +100,7 @@ pub struct User {
     pub first_name: Option<String>,
     pub last_name: Option<String>,
     // pub avatar: ?,
-    pub creation_date: chrono::NaiveDateTime,
+    pub creation_date: chrono::DateTime<chrono::Utc>,
 }
 
 impl Default for User {
@@ -111,7 +111,7 @@ impl Default for User {
             display_name: None,
             first_name: None,
             last_name: None,
-            creation_date: chrono::NaiveDateTime::from_timestamp(0, 0),
+            creation_date: Utc.timestamp(0, 0),
         }
     }
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -20,14 +20,14 @@ input RequestFilter {
   eq: EqualityConstraint
 }
 
+"DateTime"
+scalar DateTimeUtc
+
 type Query {
   apiVersion: String!
   user(userId: String!): User!
   users(filters: RequestFilter): [User!]!
 }
-
-"NaiveDateTime"
-scalar NaiveDateTime
 
 type User {
   id: String!
@@ -35,7 +35,7 @@ type User {
   displayName: String
   firstName: String
   lastName: String
-  creationDate: NaiveDateTime!
+  creationDate: DateTimeUtc!
   "The groups to which this user belongs."
   groups: [Group!]!
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -1,0 +1,38 @@
+input EqualityConstraint {
+  field: String!
+  value: String!
+}
+
+type Group {
+  id: String!
+  "The groups to which this user belongs."
+  users: [User!]!
+}
+
+"""
+  A filter for requests, specifying a boolean expression based on field constraints. Only one of
+  the fields can be set at a time.
+"""
+input RequestFilter {
+  any: [RequestFilter!]
+  all: [RequestFilter!]
+  not: RequestFilter
+  eq: EqualityConstraint
+}
+
+type Query {
+  apiVersion: String!
+  user(userId: String!): User!
+  users(filters: RequestFilter): [User!]!
+}
+
+type User {
+  id: String!
+  email: String!
+  "The groups to which this user belongs."
+  groups: [Group!]!
+}
+
+schema {
+  query: Query
+}

--- a/schema.graphql
+++ b/schema.graphql
@@ -26,9 +26,16 @@ type Query {
   users(filters: RequestFilter): [User!]!
 }
 
+"NaiveDateTime"
+scalar NaiveDateTime
+
 type User {
   id: String!
   email: String!
+  displayName: String
+  firstName: String
+  lastName: String
+  creationDate: NaiveDateTime!
   "The groups to which this user belongs."
   groups: [Group!]!
 }

--- a/src/domain/handler.rs
+++ b/src/domain/handler.rs
@@ -18,7 +18,7 @@ pub trait BackendHandler: Clone + Send {
     async fn delete_user(&self, request: DeleteUserRequest) -> Result<()>;
     async fn create_group(&self, request: CreateGroupRequest) -> Result<i32>;
     async fn add_user_to_group(&self, request: AddUserToGroupRequest) -> Result<()>;
-    async fn get_user_groups(&self, user: String) -> Result<HashSet<String>>;
+    async fn get_user_groups(&self, user: &str) -> Result<HashSet<String>>;
 }
 
 #[cfg(test)]
@@ -35,7 +35,7 @@ mockall::mock! {
         async fn create_user(&self, request: CreateUserRequest) -> Result<()>;
         async fn delete_user(&self, request: DeleteUserRequest) -> Result<()>;
         async fn create_group(&self, request: CreateGroupRequest) -> Result<i32>;
-        async fn get_user_groups(&self, user: String) -> Result<HashSet<String>>;
+        async fn get_user_groups(&self, user: &str) -> Result<HashSet<String>>;
         async fn add_user_to_group(&self, request: AddUserToGroupRequest) -> Result<()>;
     }
     #[async_trait]

--- a/src/domain/sql_backend_handler.rs
+++ b/src/domain/sql_backend_handler.rs
@@ -135,7 +135,7 @@ impl BackendHandler for SqlBackendHandler {
             .await?)
     }
 
-    async fn get_user_groups(&self, user: String) -> Result<HashSet<String>> {
+    async fn get_user_groups(&self, user: &str) -> Result<HashSet<String>> {
         if user == self.config.ldap_user_dn {
             let mut groups = HashSet::new();
             groups.insert("lldap_admin".to_string());
@@ -510,19 +510,13 @@ mod tests {
         let mut patrick_groups = HashSet::new();
         patrick_groups.insert("Group1".to_string());
         patrick_groups.insert("Group2".to_string());
+        assert_eq!(handler.get_user_groups("bob").await.unwrap(), bob_groups);
         assert_eq!(
-            handler.get_user_groups("bob".to_string()).await.unwrap(),
-            bob_groups
-        );
-        assert_eq!(
-            handler
-                .get_user_groups("patrick".to_string())
-                .await
-                .unwrap(),
+            handler.get_user_groups("patrick").await.unwrap(),
             patrick_groups
         );
         assert_eq!(
-            handler.get_user_groups("John".to_string()).await.unwrap(),
+            handler.get_user_groups("John").await.unwrap(),
             HashSet::new()
         );
     }

--- a/src/domain/sql_tables.rs
+++ b/src/domain/sql_tables.rs
@@ -120,7 +120,7 @@ pub async fn init_table(pool: &Pool) -> sqlx::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::NaiveDateTime;
+    use chrono::prelude::*;
     use sqlx::{Column, Row};
 
     #[actix_rt::test]
@@ -138,8 +138,8 @@ mod tests {
         assert_eq!(row.column(0).name(), "display_name");
         assert_eq!(row.get::<String, _>("display_name"), "Bob Bobbersön");
         assert_eq!(
-            row.get::<NaiveDateTime, _>("creation_date"),
-            NaiveDateTime::from_timestamp(0, 0)
+            row.get::<DateTime<Utc>, _>("creation_date"),
+            Utc.timestamp(0, 0),
         );
     }
 

--- a/src/infra/auth_service.rs
+++ b/src/infra/auth_service.rs
@@ -365,6 +365,12 @@ pub(crate) fn check_if_token_is_valid<Backend>(
     if token.claims().exp.lt(&Utc::now()) {
         return Err(ErrorUnauthorized("Expired JWT"));
     }
+    if token.header().algorithm != jwt::AlgorithmType::Hs512 {
+        return Err(ErrorUnauthorized(format!(
+            "Unsupported JWT algorithm: '{:?}'. Supported ones are: ['HS512']",
+            token.header().algorithm
+        )));
+    }
     let jwt_hash = {
         let mut s = DefaultHasher::new();
         token_str.hash(&mut s);

--- a/src/infra/auth_service.rs
+++ b/src/infra/auth_service.rs
@@ -89,7 +89,7 @@ where
     match res_found {
         Ok(found) => {
             if found {
-                backend_handler.get_user_groups(user.to_string()).await
+                backend_handler.get_user_groups(&user).await
             } else {
                 Err(DomainError::AuthenticationError(
                     "Invalid refresh token".to_string(),
@@ -191,7 +191,7 @@ where
     // The authentication was successful, we need to fetch the groups to create the JWT
     // token.
     data.backend_handler
-        .get_user_groups(name.to_string())
+        .get_user_groups(name)
         .and_then(|g| async { Ok((g, data.backend_handler.create_refresh_token(name).await?)) })
         .await
         .map(|(groups, (refresh_token, max_age))| {

--- a/src/infra/cli.rs
+++ b/src/infra/cli.rs
@@ -4,6 +4,23 @@ use clap::Clap;
 #[derive(Debug, Clap, Clone)]
 #[clap(version = "0.1", author = "The LLDAP team")]
 pub struct CLIOpts {
+    /// Export
+    #[clap(subcommand)]
+    pub command: Command,
+}
+
+#[derive(Debug, Clap, Clone)]
+pub enum Command {
+    /// Export the GraphQL schema to *.graphql.
+    #[clap(name = "export_graphql_schema")]
+    ExportGraphQLSchema(ExportGraphQLSchemaOpts),
+    /// Run the LDAP and GraphQL server.
+    #[clap(name = "run")]
+    Run(RunOpts),
+}
+
+#[derive(Debug, Clap, Clone)]
+pub struct RunOpts {
     /// Change config file name
     #[clap(short, long, default_value = "lldap_config.toml")]
     pub config_file: String,
@@ -19,6 +36,13 @@ pub struct CLIOpts {
     /// Set verbose logging
     #[clap(short, long)]
     pub verbose: bool,
+}
+
+#[derive(Debug, Clap, Clone)]
+pub struct ExportGraphQLSchemaOpts {
+    /// Output to a file. If not specified, the config is printed to the standard output.
+    #[clap(short, long)]
+    pub output_file: Option<String>,
 }
 
 pub fn init() -> CLIOpts {

--- a/src/infra/configuration.rs
+++ b/src/infra/configuration.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::{Context, Result};
 use figment::{
     providers::{Env, Format, Serialized, Toml},
     Figment,
@@ -93,19 +93,16 @@ fn get_server_setup(file_path: &str) -> Result<ServerSetup> {
     use std::path::Path;
     let path = Path::new(file_path);
     if path.exists() {
-        let bytes = std::fs::read(file_path)
-            .map_err(|e| anyhow!("Could not read key file `{}`: {}", file_path, e))?;
+        let bytes =
+            std::fs::read(file_path).context(format!("Could not read key file `{}`", file_path))?;
         Ok(ServerSetup::deserialize(&bytes)?)
     } else {
         let mut rng = rand::rngs::OsRng;
         let server_setup = ServerSetup::new(&mut rng);
-        std::fs::write(path, server_setup.serialize()).map_err(|e| {
-            anyhow!(
-                "Could not write the generated server setup to file `{}`: {}",
-                file_path,
-                e
-            )
-        })?;
+        std::fs::write(path, server_setup.serialize()).context(format!(
+            "Could not write the generated server setup to file `{}`",
+            file_path,
+        ))?;
         Ok(server_setup)
     }
 }

--- a/src/infra/configuration.rs
+++ b/src/infra/configuration.rs
@@ -6,7 +6,7 @@ use figment::{
 use lldap_model::opaque::{server::ServerSetup, KeyPair};
 use serde::{Deserialize, Serialize};
 
-use crate::infra::cli::CLIOpts;
+use crate::infra::cli::RunOpts;
 
 #[derive(Clone, Debug, Deserialize, Serialize, derive_builder::Builder)]
 #[builder(
@@ -55,7 +55,7 @@ impl Configuration {
         self.get_server_setup().keypair()
     }
 
-    fn merge_with_cli(mut self: Configuration, cli_opts: CLIOpts) -> Configuration {
+    fn merge_with_cli(mut self: Configuration, cli_opts: RunOpts) -> Configuration {
         if cli_opts.verbose {
             self.verbose = true;
         }
@@ -110,7 +110,7 @@ fn get_server_setup(file_path: &str) -> Result<ServerSetup> {
     }
 }
 
-pub fn init(cli_opts: CLIOpts) -> Result<Configuration> {
+pub fn init(cli_opts: RunOpts) -> Result<Configuration> {
     let config_file = cli_opts.config_file.clone();
 
     let config: Configuration = Figment::from(Serialized::defaults(Configuration::default()))

--- a/src/infra/graphql/api.rs
+++ b/src/infra/graphql/api.rs
@@ -1,0 +1,70 @@
+use crate::{
+    domain::handler::BackendHandler,
+    infra::{
+        auth_service::{check_if_token_is_valid, ValidationResults},
+        tcp_server::AppState,
+    },
+};
+use actix_web::{web, Error, HttpResponse};
+use actix_web_httpauth::extractors::bearer::BearerAuth;
+use juniper::{EmptyMutation, EmptySubscription, RootNode};
+use juniper_actix::{graphiql_handler, graphql_handler, playground_handler};
+
+use super::query::Query;
+
+pub struct Context<Handler: BackendHandler> {
+    pub handler: Box<Handler>,
+    pub validation_result: ValidationResults,
+}
+
+impl<Handler: BackendHandler> juniper::Context for Context<Handler> {}
+
+type Schema<Handler> = RootNode<
+    'static,
+    Query<Handler>,
+    EmptyMutation<Context<Handler>>,
+    EmptySubscription<Context<Handler>>,
+>;
+
+fn schema<Handler: BackendHandler + Sync>() -> Schema<Handler> {
+    Schema::new(
+        Query::<Handler>::new(),
+        EmptyMutation::<Context<Handler>>::new(),
+        EmptySubscription::<Context<Handler>>::new(),
+    )
+}
+
+async fn graphiql_route() -> Result<HttpResponse, Error> {
+    graphiql_handler("/api/graphql", None).await
+}
+async fn playground_route() -> Result<HttpResponse, Error> {
+    playground_handler("/api/graphql", None).await
+}
+
+async fn graphql_route<Handler: BackendHandler + Sync>(
+    req: actix_web::HttpRequest,
+    mut payload: actix_web::web::Payload,
+    data: web::Data<AppState<Handler>>,
+) -> Result<HttpResponse, Error> {
+    use actix_web::FromRequest;
+    let bearer = BearerAuth::from_request(&req, &mut payload.0).await?;
+    let validation_result = check_if_token_is_valid(&data, bearer.token())?;
+    let context = Context::<Handler> {
+        handler: Box::new(data.backend_handler.clone()),
+        validation_result,
+    };
+    graphql_handler(&schema(), &context, req, payload).await
+}
+
+pub fn configure_endpoint<Backend>(cfg: &mut web::ServiceConfig)
+where
+    Backend: BackendHandler + Sync + 'static,
+{
+    cfg.service(
+        web::resource("/graphql")
+            .route(web::post().to(graphql_route::<Backend>))
+            .route(web::get().to(graphql_route::<Backend>)),
+    );
+    cfg.service(web::resource("/graphql/playground").route(web::get().to(playground_route)));
+    cfg.service(web::resource("/graphql/graphiql").route(web::get().to(graphiql_route)));
+}

--- a/src/infra/graphql/mod.rs
+++ b/src/infra/graphql/mod.rs
@@ -1,0 +1,2 @@
+pub mod api;
+pub mod query;

--- a/src/infra/graphql/query.rs
+++ b/src/infra/graphql/query.rs
@@ -145,6 +145,22 @@ impl<Handler: BackendHandler + Sync> User<Handler> {
         &self.user.email
     }
 
+    fn display_name(&self) -> Option<&String> {
+        self.user.display_name.as_ref()
+    }
+
+    fn first_name(&self) -> Option<&String> {
+        self.user.first_name.as_ref()
+    }
+
+    fn last_name(&self) -> Option<&String> {
+        self.user.last_name.as_ref()
+    }
+
+    fn creation_date(&self) -> chrono::NaiveDateTime {
+        self.user.creation_date
+    }
+
     /// The groups to which this user belongs.
     async fn groups(&self, context: &Context<Handler>) -> FieldResult<Vec<Group<Handler>>> {
         Ok(context

--- a/src/infra/graphql/query.rs
+++ b/src/infra/graphql/query.rs
@@ -157,7 +157,7 @@ impl<Handler: BackendHandler + Sync> User<Handler> {
         self.user.last_name.as_ref()
     }
 
-    fn creation_date(&self) -> chrono::NaiveDateTime {
+    fn creation_date(&self) -> chrono::DateTime<chrono::Utc> {
         self.user.creation_date
     }
 

--- a/src/infra/graphql/query.rs
+++ b/src/infra/graphql/query.rs
@@ -1,0 +1,340 @@
+use crate::domain::handler::BackendHandler;
+use juniper::{graphql_object, FieldResult, GraphQLInputObject};
+use lldap_model::{ListUsersRequest, UserDetailsRequest};
+use serde::{Deserialize, Serialize};
+use std::convert::TryInto;
+
+use super::api::Context;
+
+#[derive(PartialEq, Eq, Debug, GraphQLInputObject)]
+/// A filter for requests, specifying a boolean expression based on field constraints. Only one of
+/// the fields can be set at a time.
+pub struct RequestFilter {
+    any: Option<Vec<RequestFilter>>,
+    all: Option<Vec<RequestFilter>>,
+    not: Option<Box<RequestFilter>>,
+    eq: Option<EqualityConstraint>,
+}
+
+impl TryInto<lldap_model::RequestFilter> for RequestFilter {
+    type Error = String;
+    fn try_into(self) -> Result<lldap_model::RequestFilter, Self::Error> {
+        let mut field_count = 0;
+        if self.any.is_some() {
+            field_count += 1;
+        }
+        if self.all.is_some() {
+            field_count += 1;
+        }
+        if self.not.is_some() {
+            field_count += 1;
+        }
+        if self.eq.is_some() {
+            field_count += 1;
+        }
+        if field_count == 0 {
+            return Err("No field specified in request filter".to_string());
+        }
+        if field_count > 1 {
+            return Err("Multiple fields specified in request filter".to_string());
+        }
+        if let Some(e) = self.eq {
+            return Ok(lldap_model::RequestFilter::Equality(e.field, e.value));
+        }
+        if let Some(c) = self.any {
+            return Ok(lldap_model::RequestFilter::Or(
+                c.into_iter()
+                    .map(TryInto::try_into)
+                    .collect::<Result<Vec<_>, String>>()?,
+            ));
+        }
+        if let Some(c) = self.all {
+            return Ok(lldap_model::RequestFilter::And(
+                c.into_iter()
+                    .map(TryInto::try_into)
+                    .collect::<Result<Vec<_>, String>>()?,
+            ));
+        }
+        if let Some(c) = self.not {
+            return Ok(lldap_model::RequestFilter::Not(Box::new((*c).try_into()?)));
+        }
+        unreachable!();
+    }
+}
+
+#[derive(PartialEq, Eq, Debug, GraphQLInputObject)]
+pub struct EqualityConstraint {
+    field: String,
+    value: String,
+}
+
+#[derive(PartialEq, Eq, Debug)]
+/// The top-level GraphQL query type.
+pub struct Query<Handler: BackendHandler> {
+    _phantom: std::marker::PhantomData<Box<Handler>>,
+}
+
+impl<Handler: BackendHandler> Query<Handler> {
+    pub fn new() -> Self {
+        Self {
+            _phantom: std::marker::PhantomData,
+        }
+    }
+}
+
+#[graphql_object(context = Context<Handler>)]
+impl<Handler: BackendHandler + Sync> Query<Handler> {
+    fn api_version() -> &'static str {
+        "1.0"
+    }
+
+    async fn user(context: &Context<Handler>, user_id: String) -> FieldResult<User<Handler>> {
+        if !context.validation_result.can_access(&user_id) {
+            return Err("Unauthorized access to user data".into());
+        }
+        Ok(context
+            .handler
+            .get_user_details(UserDetailsRequest { user_id })
+            .await
+            .map(Into::into)?)
+    }
+
+    async fn users(
+        context: &Context<Handler>,
+        #[graphql(name = "where")] filters: Option<RequestFilter>,
+    ) -> FieldResult<Vec<User<Handler>>> {
+        if !context.validation_result.is_admin {
+            return Err("Unauthorized access to user list".into());
+        }
+        Ok(context
+            .handler
+            .list_users(ListUsersRequest {
+                filters: match filters {
+                    None => None,
+                    Some(f) => Some(f.try_into()?),
+                },
+            })
+            .await
+            .map(|v| v.into_iter().map(Into::into).collect())?)
+    }
+}
+
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize)]
+/// Represents a single user.
+pub struct User<Handler: BackendHandler> {
+    user: lldap_model::User,
+    _phantom: std::marker::PhantomData<Box<Handler>>,
+}
+
+impl<Handler: BackendHandler> Default for User<Handler> {
+    fn default() -> Self {
+        Self {
+            user: lldap_model::User::default(),
+            _phantom: std::marker::PhantomData,
+        }
+    }
+}
+
+#[graphql_object(context = Context<Handler>)]
+impl<Handler: BackendHandler + Sync> User<Handler> {
+    fn id(&self) -> &str {
+        &self.user.user_id
+    }
+
+    fn email(&self) -> &str {
+        &self.user.email
+    }
+
+    /// The groups to which this user belongs.
+    async fn groups(&self, context: &Context<Handler>) -> FieldResult<Vec<Group<Handler>>> {
+        Ok(context
+            .handler
+            .get_user_groups(self.user.user_id.clone())
+            .await
+            .map(|set| set.into_iter().map(Into::into).collect())?)
+    }
+}
+
+impl<Handler: BackendHandler> From<lldap_model::User> for User<Handler> {
+    fn from(user: lldap_model::User) -> Self {
+        Self {
+            user,
+            _phantom: std::marker::PhantomData,
+        }
+    }
+}
+
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize)]
+/// Represents a single group.
+pub struct Group<Handler: BackendHandler> {
+    group_id: String,
+    _phantom: std::marker::PhantomData<Box<Handler>>,
+}
+
+#[graphql_object(context = Context<Handler>)]
+impl<Handler: BackendHandler + Sync> Group<Handler> {
+    fn id(&self) -> String {
+        self.group_id.clone()
+    }
+    /// The groups to which this user belongs.
+    async fn users(&self, context: &Context<Handler>) -> FieldResult<Vec<User<Handler>>> {
+        if !context.validation_result.is_admin {
+            return Err("Unauthorized access to group data".into());
+        }
+        unimplemented!()
+    }
+}
+
+impl<Handler: BackendHandler> From<String> for Group<Handler> {
+    fn from(group_id: String) -> Self {
+        Self {
+            group_id,
+            _phantom: std::marker::PhantomData,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{domain::handler::MockTestBackendHandler, infra::auth_service::ValidationResults};
+    use juniper::{
+        execute, graphql_value, DefaultScalarValue, EmptyMutation, EmptySubscription, GraphQLType,
+        RootNode, Variables,
+    };
+    use mockall::predicate::eq;
+    use std::collections::HashSet;
+
+    fn schema<'q, C, Q>(query_root: Q) -> RootNode<'q, Q, EmptyMutation<C>, EmptySubscription<C>>
+    where
+        Q: GraphQLType<DefaultScalarValue, Context = C, TypeInfo = ()> + 'q,
+    {
+        RootNode::new(
+            query_root,
+            EmptyMutation::<C>::new(),
+            EmptySubscription::<C>::new(),
+        )
+    }
+
+    #[tokio::test]
+    async fn get_user_by_id() {
+        const QUERY: &str = r#"{
+          user(userId: "bob") {
+            id
+            email
+            groups {
+              id
+            }
+          }
+        }"#;
+
+        let mut mock = MockTestBackendHandler::new();
+        mock.expect_get_user_details()
+            .with(eq(UserDetailsRequest {
+                user_id: "bob".to_string(),
+            }))
+            .return_once(|_| {
+                Ok(lldap_model::User {
+                    user_id: "bob".to_string(),
+                    email: "bob@bobbers.on".to_string(),
+                    ..Default::default()
+                })
+            });
+        let mut groups = HashSet::<String>::new();
+        groups.insert("Bobbersons".to_string());
+        mock.expect_get_user_groups()
+            .with(eq("bob".to_string()))
+            .return_once(|_| Ok(groups));
+
+        let context = Context::<MockTestBackendHandler> {
+            handler: Box::new(mock),
+            validation_result: ValidationResults::admin(),
+        };
+
+        let schema = schema(Query::<MockTestBackendHandler>::new());
+        assert_eq!(
+            execute(QUERY, None, &schema, &Variables::new(), &context).await,
+            Ok((
+                graphql_value!(
+                {
+                    "user": {
+                        "id": "bob",
+                        "email": "bob@bobbers.on",
+                        "groups": [{"id": "Bobbersons"}]
+                    }
+                }),
+                vec![]
+            ))
+        );
+    }
+
+    #[tokio::test]
+    async fn list_users() {
+        const QUERY: &str = r#"{
+          users(filters: {
+            any: [
+              {eq: {
+                field: "id"
+                value: "bob"
+              }},
+              {eq: {
+                field: "email"
+                value: "robert@bobbers.on"
+              }}
+            ]}) {
+            id
+            email
+          }
+        }"#;
+
+        let mut mock = MockTestBackendHandler::new();
+        use lldap_model::{RequestFilter, User};
+        mock.expect_list_users()
+            .with(eq(ListUsersRequest {
+                filters: Some(RequestFilter::Or(vec![
+                    RequestFilter::Equality("id".to_string(), "bob".to_string()),
+                    RequestFilter::Equality("email".to_string(), "robert@bobbers.on".to_string()),
+                ])),
+            }))
+            .return_once(|_| {
+                Ok(vec![
+                    User {
+                        user_id: "bob".to_string(),
+                        email: "bob@bobbers.on".to_string(),
+                        ..Default::default()
+                    },
+                    User {
+                        user_id: "robert".to_string(),
+                        email: "robert@bobbers.on".to_string(),
+                        ..Default::default()
+                    },
+                ])
+            });
+
+        let context = Context::<MockTestBackendHandler> {
+            handler: Box::new(mock),
+            validation_result: ValidationResults::admin(),
+        };
+
+        let schema = schema(Query::<MockTestBackendHandler>::new());
+        assert_eq!(
+            execute(QUERY, None, &schema, &Variables::new(), &context).await,
+            Ok((
+                graphql_value!(
+                {
+                    "users": [
+                        {
+                            "id": "bob",
+                            "email": "bob@bobbers.on"
+                        },
+                        {
+                            "id": "robert",
+                            "email": "robert@bobbers.on"
+                        },
+                    ]
+                }),
+                vec![]
+            ))
+        );
+    }
+}

--- a/src/infra/graphql/query.rs
+++ b/src/infra/graphql/query.rs
@@ -149,7 +149,7 @@ impl<Handler: BackendHandler + Sync> User<Handler> {
     async fn groups(&self, context: &Context<Handler>) -> FieldResult<Vec<Group<Handler>>> {
         Ok(context
             .handler
-            .get_user_groups(self.user.user_id.clone())
+            .get_user_groups(&self.user.user_id)
             .await
             .map(|set| set.into_iter().map(Into::into).collect())?)
     }
@@ -243,7 +243,7 @@ mod tests {
         let mut groups = HashSet::<String>::new();
         groups.insert("Bobbersons".to_string());
         mock.expect_get_user_groups()
-            .with(eq("bob".to_string()))
+            .with(eq("bob"))
             .return_once(|_| Ok(groups));
 
         let context = Context::<MockTestBackendHandler> {

--- a/src/infra/ldap_handler.rs
+++ b/src/infra/ldap_handler.rs
@@ -277,7 +277,6 @@ mod tests {
     use super::*;
     use crate::domain::handler::BindRequest;
     use crate::domain::handler::MockTestBackendHandler;
-    use chrono::NaiveDateTime;
     use mockall::predicate::eq;
     use tokio;
 
@@ -487,7 +486,7 @@ mod tests {
                     display_name: Some("Bôb Böbberson".to_string()),
                     first_name: Some("Bôb".to_string()),
                     last_name: Some("Böbberson".to_string()),
-                    creation_date: NaiveDateTime::from_timestamp(1_000_000, 0),
+                    ..Default::default()
                 },
                 User {
                     user_id: "jim".to_string(),
@@ -495,7 +494,7 @@ mod tests {
                     display_name: Some("Jimminy Cricket".to_string()),
                     first_name: Some("Jim".to_string()),
                     last_name: Some("Cricket".to_string()),
-                    creation_date: NaiveDateTime::from_timestamp(1_500_000, 0),
+                    ..Default::default()
                 },
             ])
         });

--- a/src/infra/mod.rs
+++ b/src/infra/mod.rs
@@ -2,6 +2,7 @@ pub mod auth_service;
 pub mod cli;
 pub mod configuration;
 pub mod db_cleaner;
+pub mod graphql;
 pub mod jwt_sql_tables;
 pub mod ldap_handler;
 pub mod ldap_server;

--- a/src/infra/tcp_api.rs
+++ b/src/infra/tcp_api.rs
@@ -62,7 +62,7 @@ where
 
 pub fn api_config<Backend>(cfg: &mut web::ServiceConfig)
 where
-    Backend: TcpBackendHandler + BackendHandler + 'static,
+    Backend: TcpBackendHandler + BackendHandler + Sync + 'static,
 {
     let json_config = web::JsonConfig::default()
         .limit(4096)
@@ -77,6 +77,7 @@ where
             .into()
         });
     cfg.app_data(json_config);
+    super::graphql::api::configure_endpoint::<Backend>(cfg);
     cfg.service(
         web::resource("/user/{user_id}")
             .route(web::get().to(user_details_handler::<Backend>))

--- a/src/infra/tcp_backend_handler.rs
+++ b/src/infra/tcp_backend_handler.rs
@@ -29,7 +29,7 @@ mockall::mock! {
         async fn list_users(&self, request: ListUsersRequest) -> DomainResult<Vec<User>>;
         async fn list_groups(&self) -> DomainResult<Vec<Group>>;
         async fn get_user_details(&self, request: UserDetailsRequest) -> DomainResult<User>;
-        async fn get_user_groups(&self, user: String) -> DomainResult<HashSet<String>>;
+        async fn get_user_groups(&self, user: &str) -> DomainResult<HashSet<String>>;
         async fn create_user(&self, request: CreateUserRequest) -> DomainResult<()>;
         async fn delete_user(&self, request: DeleteUserRequest) -> DomainResult<()>;
         async fn create_group(&self, request: CreateGroupRequest) -> DomainResult<i32>;

--- a/src/infra/tcp_server.rs
+++ b/src/infra/tcp_server.rs
@@ -49,11 +49,11 @@ fn http_config<Backend>(
 ) where
     Backend: TcpBackendHandler + BackendHandler + LoginHandler + OpaqueHandler + 'static,
 {
-    cfg.app_data(AppState::<Backend> {
+    cfg.app_data(web::Data::new(AppState::<Backend> {
         backend_handler,
         jwt_key: Hmac::new_varkey(jwt_secret.as_bytes()).unwrap(),
         jwt_blacklist: RwLock::new(jwt_blacklist),
-    })
+    }))
     // Serve index.html and main.js, and default to index.html.
     .route(
         "/{filename:(index\\.html|main\\.js)?}",

--- a/src/infra/tcp_server.rs
+++ b/src/infra/tcp_server.rs
@@ -47,7 +47,7 @@ fn http_config<Backend>(
     jwt_secret: String,
     jwt_blacklist: HashSet<u64>,
 ) where
-    Backend: TcpBackendHandler + BackendHandler + LoginHandler + OpaqueHandler + 'static,
+    Backend: TcpBackendHandler + BackendHandler + LoginHandler + OpaqueHandler + Sync + 'static,
 {
     cfg.app_data(web::Data::new(AppState::<Backend> {
         backend_handler,
@@ -84,7 +84,7 @@ pub async fn build_tcp_server<Backend>(
     server_builder: ServerBuilder,
 ) -> Result<ServerBuilder>
 where
-    Backend: TcpBackendHandler + BackendHandler + LoginHandler + OpaqueHandler + 'static,
+    Backend: TcpBackendHandler + BackendHandler + LoginHandler + OpaqueHandler + Sync + 'static,
 {
     let jwt_secret = config.jwt_secret.clone();
     let jwt_blacklist = backend_handler.get_jwt_blacklist().await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use crate::{
     infra::{cli::*, configuration::Configuration, db_cleaner::Scheduler},
 };
 use actix::Actor;
-use anyhow::{anyhow, Result};
+use anyhow::{Context, Result};
 use futures_util::TryFutureExt;
 use log::*;
 
@@ -24,20 +24,20 @@ async fn create_admin_user(handler: &SqlBackendHandler, config: &Configuration) 
         })
         .and_then(|_| register_password(handler, &config.ldap_user_dn, &config.ldap_user_pass))
         .await
-        .map_err(|e| anyhow!("Error creating admin user: {}", e))?;
+        .context("Error creating admin user")?;
     let admin_group_id = handler
         .create_group(lldap_model::CreateGroupRequest {
             display_name: "lldap_admin".to_string(),
         })
         .await
-        .map_err(|e| anyhow!("Error creating admin group: {}", e))?;
+        .context("Error creating admin group")?;
     handler
         .add_user_to_group(lldap_model::AddUserToGroupRequest {
             user_id: config.ldap_user_dn.clone(),
             group_id: admin_group_id,
         })
         .await
-        .map_err(|e| anyhow!("Error adding admin user to group: {}", e))
+        .context("Error adding admin user to group")
 }
 
 async fn run_server(config: Configuration) -> Result<()> {


### PR DESCRIPTION
This PR introduces a new endpoint as a GraphQL endpoint. That will help simplify introducing new REST methods (as GraphQL queries instead) and apply best practices.
Auth is still done separately using OPAQUE.

Eventually, `lldap_model` can be stripped to just the `opaque` module, since the rest of the data layout is communicated through the GraphQL schema only, simplifying documentation and client integration.