### PR TITLE
config: Add a minimum password length

### DIFF
--- a/lldap_config.docker_template.toml
+++ b/lldap_config.docker_template.toml
@@ -38,6 +38,7 @@
 ## Admin password.
 ## Password for the admin account, both for the LDAP bind and for the
 ## administration interface.
+## It should be minimum 8 characters long.
 ## You can set it with the LDAP_USER_PASS environment variable.
 ## Note: you can create another admin user for LDAP/administration, this
 ## is just the default one.

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -11,7 +11,7 @@ use crate::{
     infra::{cli::*, configuration::Configuration, db_cleaner::Scheduler},
 };
 use actix::Actor;
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use futures_util::TryFutureExt;
 use log::*;
 
@@ -19,6 +19,9 @@ mod domain;
 mod infra;
 
 async fn create_admin_user(handler: &SqlBackendHandler, config: &Configuration) -> Result<()> {
+    if config.ldap_user_pass.len() < 8 {
+        bail!("Minimum password length is 8 characters");
+    }
     handler
         .create_user(CreateUserRequest {
             user_id: config.ldap_user_dn.clone(),


### PR DESCRIPTION
That way it won't be possible to create an admin password that the interface refuses. See #48.