### PR TITLE
(Doc) Keycloak requires a full DN, not just the username

### DIFF
--- a/example_configs/keycloak.md
+++ b/example_configs/keycloak.md
@@ -25,7 +25,7 @@ The key settings are:
  - Connection URL: `ldap://<your-lldap-container>:3890`
  - Users DN: `ou=people,dc=example,dc=com` (or whatever `dc` you have)
  - Bind Type: `simple`
- - Bind DN: `admin` (your LLDAP admin user)
+ - Bind DN: `cn=admin,ou=people,dc=example,dc=com` (replace with your admin user and `dc`)
  - Bind Credential: your LLDAP admin password
 
 Test the connection and authentication, it should work.


### PR DESCRIPTION
Something I noticed when setting up Keycloak. Setting just "admin" for the bind DN doesn't work. Instead you have to set the whole DN: `cn=admin,ou=people,dc=example,dc=com`