### PR TITLE
Add an entrypoint script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,9 +52,8 @@ RUN set -x \
         --uid 10001 \
         app \
     # Create the /data folder
-    && mkdir /data && chown app:app /data
-
-RUN apk add --no-cache bash
+    && mkdir /data && chown app:app /data \
+    && apk add --no-cache bash
 
 USER app
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Configure the server by copying the `lldap_config.docker_template.toml` to
 Environment variables should be prefixed with `LLDAP_` to override the
 configuration.
 
+Secrets can also be set through a file. The filename should be specified by the variables `LLDAP_JWT_SECRET_FILE` or `LLDAP_USER_PASS_FILE`, and the file contents are loaded into the respective configuration parameters. Note that `_FILE` variables take precedence.
+
 Example for docker compose:
 
 ```yaml

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+for SECRET in LLDAP_JWT_SECRET LLDAP_LDAP_USER_PASS; do
+    FILE_VAR="${SECRET}_FILE"
+    SECRET_FILE="${!FILE_VAR:-}"
+    if [[ -n "$SECRET_FILE" ]]; then
+        if [[ -f "$SECRET_FILE" ]]; then
+            declare "$SECRET=$(cat $SECRET_FILE)"
+            export "$SECRET"
+            echo "[entrypoint] Set $SECRET from $SECRET_FILE"
+        else
+            echo "[entrypoint] Could not read contents of $SECRET_FILE (specified in $FILE_VAR)" >&2
+        fi
+    fi
+done
+
+exec /app/lldap "$@"

--- a/lldap_config.docker_template.toml
+++ b/lldap_config.docker_template.toml
@@ -20,6 +20,8 @@
 ## them to re-login.
 ## You should probably set it through the LLDAP_JWT_SECRET environment
 ## variable from a secret ".env" file.
+## This can also be set from a file's contents by specifying the file path 
+## in the LLDAP_JWT_SECRET_FILE environment variable
 ## You can generate it with (on linux):
 ## LC_ALL=C tr -dc 'A-Za-z0-9!"#%&'\''()*+,-./:;<=>?@[\]^_{|}~' </dev/urandom | head -c 32; echo ''
 #jwt_secret = "REPLACE_WITH_RANDOM"
@@ -45,6 +47,8 @@
 ## the admin user.
 ## It should be minimum 8 characters long.
 ## You can set it with the LLDAP_LDAP_USER_PASS environment variable.
+## This can also be set from a file's contents by specifying the file path
+## in the LLDAP_USER_PASS_FILE environment variable
 ## Note: you can create another admin user for user administration, this
 ## is just the default one.
 #ldap_user_pass = "REPLACE_WITH_PASSWORD"


### PR DESCRIPTION
The script allows secrets to be set via env var defined filenames, and preserves the ability to pass different `lldap` subcommands/args via the docker command.

Documentation was updated to note the changes.

I took the liberty of pinning the upstream builder and base containers to alpine 3.14 since I noticed `alpine:latest` points to 3.15 while `rust:alpine` uses 3.14. I doubt its causing any issues, but it seems smart to control which versions are used rather than just pointing to latest. Let me know if you have a reason to keep it on latest and I can remove that change.

Addresses #84 