### PR TITLE
Fix issues with docker around users and permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,26 +42,16 @@ RUN cargo build --release -p lldap \
 # Final image
 FROM alpine:3.14
 
-RUN set -x \
-    # Add user
-    && addgroup --gid 10001 app \
-    && adduser --disabled-password \
-        --gecos '' \
-        --ingroup app \
-        --home /app \
-        --uid 10001 \
-        app \
-    # Create the /data folder
-    && mkdir /data && chown app:app /data \
-    && apk add --no-cache bash
-
-USER app
 WORKDIR /app
 
-COPY --chown=app:app --from=builder /app/app/index.html /app/app/main.js /app/app/style.css app/
-COPY --chown=app:app --from=builder /app/app/pkg app/pkg
-COPY --chown=app:app --from=builder /app/target/release/lldap lldap
-COPY docker-entrypoint.sh .
+COPY --from=builder /app/app/index.html /app/app/main.js /app/app/style.css app/
+COPY --from=builder /app/app/pkg app/pkg
+COPY --from=builder /app/target/release/lldap lldap
+COPY docker-entrypoint.sh lldap_config.docker_template.toml ./
+
+RUN set -x \
+    && apk add --no-cache bash \
+    && chmod a+r -R .
 
 ENV LDAP_PORT=3890
 ENV HTTP_PORT=17170

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ volumes:
 services:
   lldap:
     image: nitnelave/lldap
+    # Change this to the user:group you want.
+    user: "33:33"
     ports:
       # For LDAP
       - "3890:3890"
@@ -90,6 +92,8 @@ services:
       - "17170:17170"
     volumes:
       - "lldap_data:/data"
+      # Alternatively, you can mount a local folder
+      # - "./lldap_data:/data"
     environment:
       - LLDAP_JWT_SECRET=REPLACE_WITH_RANDOM
       - LLDAP_LDAP_USER_PASS=REPLACE_WITH_PASSWORD

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -15,4 +15,24 @@ for SECRET in LLDAP_JWT_SECRET LLDAP_LDAP_USER_PASS; do
     fi
 done
 
+CONFIG_FILE=/data/lldap_config.toml
+
+if [[ ( ! -w "/data" ) ]] || [[ ( ! -d "/data" ) ]]; then
+  echo "[entrypoint] The /data folder doesn't exist or cannot be written to. Make sure to mount
+  a volume or folder to /data to persist data across restarts, and that the current user can
+  write to it."
+  exit 1
+fi
+
+if [[ ! -f "$CONFIG_FILE" ]]; then
+  echo "[entrypoint] Copying the default config to $CONFIG_FILE"
+  echo "[entrypoint] Edit this file to configure LLDAP."
+  cp /app/lldap_config.docker_template.toml $CONFIG_FILE
+fi
+
+if [[ ! -r "$CONFIG_FILE" ]]; then
+  echo "[entrypoint] Config file is not readable. Check the permissions"
+  exit 1;
+fi
+
 exec /app/lldap "$@"

--- a/server/src/infra/cli.rs
+++ b/server/src/infra/cli.rs
@@ -45,6 +45,11 @@ pub struct RunOpts {
     #[clap(flatten)]
     pub general_config: GeneralConfigOpts,
 
+    /// Path to the file that contains the private server key.
+    /// It will be created if it doesn't exist.
+    #[clap(long, env = "LLDAP_SERVER_KEY_FILE")]
+    pub server_key_file: Option<String>,
+
     /// Change ldap port. Default: 3890
     #[clap(long, env = "LLDAP_LDAP_PORT")]
     pub ldap_port: Option<u16>,


### PR DESCRIPTION
By making the /app folder world-readable, we have nothing that ties us to the `app` user, so we can run the container as any user. This, and some added startup checks for permissions, should help with most issues that users experience.

Fixes #86 