### PR TITLE
Refactor groups to use filters internally

### DIFF
--- a/server/src/domain/handler.rs
+++ b/server/src/domain/handler.rs
@@ -54,6 +54,17 @@ pub enum UserRequestFilter {
     MemberOfId(GroupId),
 }
 
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
+pub enum GroupRequestFilter {
+    And(Vec<GroupRequestFilter>),
+    Or(Vec<GroupRequestFilter>),
+    Not(Box<GroupRequestFilter>),
+    DisplayName(String),
+    GroupId(GroupId),
+    // Check if the group contains a user identified by uid.
+    Member(String),
+}
+
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone, Default)]
 pub struct CreateUserRequest {
     // Same fields as User, but no creation_date, and with password.
@@ -94,7 +105,7 @@ pub struct GroupIdAndName(pub GroupId, pub String);
 #[async_trait]
 pub trait BackendHandler: Clone + Send {
     async fn list_users(&self, filters: Option<UserRequestFilter>) -> Result<Vec<User>>;
-    async fn list_groups(&self) -> Result<Vec<Group>>;
+    async fn list_groups(&self, filters: Option<GroupRequestFilter>) -> Result<Vec<Group>>;
     async fn get_user_details(&self, user_id: &str) -> Result<User>;
     async fn get_group_details(&self, group_id: GroupId) -> Result<GroupIdAndName>;
     async fn create_user(&self, request: CreateUserRequest) -> Result<()>;
@@ -117,7 +128,7 @@ mockall::mock! {
     #[async_trait]
     impl BackendHandler for TestBackendHandler {
         async fn list_users(&self, filters: Option<UserRequestFilter>) -> Result<Vec<User>>;
-        async fn list_groups(&self) -> Result<Vec<Group>>;
+        async fn list_groups(&self, filters: Option<GroupRequestFilter>) -> Result<Vec<Group>>;
         async fn get_user_details(&self, user_id: &str) -> Result<User>;
         async fn get_group_details(&self, group_id: GroupId) -> Result<GroupIdAndName>;
         async fn create_user(&self, request: CreateUserRequest) -> Result<()>;

--- a/server/src/domain/handler.rs
+++ b/server/src/domain/handler.rs
@@ -43,10 +43,10 @@ pub struct BindRequest {
 }
 
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Clone)]
-pub enum RequestFilter {
-    And(Vec<RequestFilter>),
-    Or(Vec<RequestFilter>),
-    Not(Box<RequestFilter>),
+pub enum UserRequestFilter {
+    And(Vec<UserRequestFilter>),
+    Or(Vec<UserRequestFilter>),
+    Not(Box<UserRequestFilter>),
     Equality(String, String),
     // Check if a user belongs to a group identified by name.
     MemberOf(String),
@@ -93,7 +93,7 @@ pub struct GroupIdAndName(pub GroupId, pub String);
 
 #[async_trait]
 pub trait BackendHandler: Clone + Send {
-    async fn list_users(&self, filters: Option<RequestFilter>) -> Result<Vec<User>>;
+    async fn list_users(&self, filters: Option<UserRequestFilter>) -> Result<Vec<User>>;
     async fn list_groups(&self) -> Result<Vec<Group>>;
     async fn get_user_details(&self, user_id: &str) -> Result<User>;
     async fn get_group_details(&self, group_id: GroupId) -> Result<GroupIdAndName>;
@@ -116,7 +116,7 @@ mockall::mock! {
     }
     #[async_trait]
     impl BackendHandler for TestBackendHandler {
-        async fn list_users(&self, filters: Option<RequestFilter>) -> Result<Vec<User>>;
+        async fn list_users(&self, filters: Option<UserRequestFilter>) -> Result<Vec<User>>;
         async fn list_groups(&self) -> Result<Vec<Group>>;
         async fn get_user_details(&self, user_id: &str) -> Result<User>;
         async fn get_group_details(&self, group_id: GroupId) -> Result<GroupIdAndName>;

--- a/server/src/infra/graphql/query.rs
+++ b/server/src/infra/graphql/query.rs
@@ -2,7 +2,7 @@ use crate::domain::handler::{BackendHandler, GroupId, GroupIdAndName};
 use juniper::{graphql_object, FieldResult, GraphQLInputObject};
 use serde::{Deserialize, Serialize};
 
-type DomainRequestFilter = crate::domain::handler::RequestFilter;
+type DomainRequestFilter = crate::domain::handler::UserRequestFilter;
 type DomainUser = crate::domain::handler::User;
 type DomainGroup = crate::domain::handler::Group;
 use super::api::Context;
@@ -269,7 +269,10 @@ impl<Handler: BackendHandler> From<DomainGroup> for Group<Handler> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{domain::handler::MockTestBackendHandler, infra::auth_service::ValidationResults};
+    use crate::{
+        domain::handler::{MockTestBackendHandler, UserRequestFilter},
+        infra::auth_service::ValidationResults,
+    };
     use juniper::{
         execute, graphql_value, DefaultScalarValue, EmptyMutation, EmptySubscription, GraphQLType,
         RootNode, Variables,
@@ -358,11 +361,10 @@ mod tests {
         }"#;
 
         let mut mock = MockTestBackendHandler::new();
-        use crate::domain::handler::RequestFilter;
         mock.expect_list_users()
-            .with(eq(Some(RequestFilter::Or(vec![
-                RequestFilter::Equality("id".to_string(), "bob".to_string()),
-                RequestFilter::Equality("email".to_string(), "robert@bobbers.on".to_string()),
+            .with(eq(Some(UserRequestFilter::Or(vec![
+                UserRequestFilter::Equality("id".to_string(), "bob".to_string()),
+                UserRequestFilter::Equality("email".to_string(), "robert@bobbers.on".to_string()),
             ]))))
             .return_once(|_| {
                 Ok(vec![

--- a/server/src/infra/graphql/query.rs
+++ b/server/src/infra/graphql/query.rs
@@ -134,7 +134,7 @@ impl<Handler: BackendHandler + Sync> Query<Handler> {
         }
         Ok(context
             .handler
-            .list_groups()
+            .list_groups(None)
             .await
             .map(|v| v.into_iter().map(Into::into).collect())?)
     }

--- a/server/src/infra/tcp_backend_handler.rs
+++ b/server/src/infra/tcp_backend_handler.rs
@@ -36,7 +36,7 @@ mockall::mock! {
     #[async_trait]
     impl BackendHandler for TestTcpBackendHandler {
         async fn list_users(&self, filters: Option<UserRequestFilter>) -> Result<Vec<User>>;
-        async fn list_groups(&self) -> Result<Vec<Group>>;
+        async fn list_groups(&self, filters: Option<GroupRequestFilter>) -> Result<Vec<Group>>;
         async fn get_user_details(&self, user_id: &str) -> Result<User>;
         async fn get_group_details(&self, group_id: GroupId) -> Result<GroupIdAndName>;
         async fn get_user_groups(&self, user: &str) -> Result<HashSet<GroupIdAndName>>;

--- a/server/src/infra/tcp_backend_handler.rs
+++ b/server/src/infra/tcp_backend_handler.rs
@@ -35,7 +35,7 @@ mockall::mock! {
     }
     #[async_trait]
     impl BackendHandler for TestTcpBackendHandler {
-        async fn list_users(&self, filters: Option<RequestFilter>) -> Result<Vec<User>>;
+        async fn list_users(&self, filters: Option<UserRequestFilter>) -> Result<Vec<User>>;
         async fn list_groups(&self) -> Result<Vec<Group>>;
         async fn get_user_details(&self, user_id: &str) -> Result<User>;
         async fn get_group_details(&self, group_id: GroupId) -> Result<GroupIdAndName>;


### PR DESCRIPTION
This should greatly expand to usability of group requests.

Fixes #103 .