### PR TITLE
Accept "uid" in qualified name

### DIFF
--- a/example_configs/authelia_config.yml
+++ b/example_configs/authelia_config.yml
@@ -42,6 +42,6 @@ authentication_backend:
     display_name_attribute: displayName
     # The username and password of the admin user.
     # "admin" should be the admin username you set in the LLDAP configuration
-    user: cn=admin,ou=people,dc=example,dc=com
+    user: uid=admin,ou=people,dc=example,dc=com
     # Password can also be set using a secret: https://www.authelia.com/docs/configuration/secrets.html
     password: 'REPLACE_ME'

--- a/example_configs/bookstack.env.example
+++ b/example_configs/bookstack.env.example
@@ -16,13 +16,13 @@ LDAP_BASE_DN=ou=people,dc=example,dc=com
 
 # The full DN and password of the user used to search the server
 # Can both be left as false to bind anonymously
-LDAP_DN=cn=admin,ou=people,dc=example,dc=com
+LDAP_DN=uid=admin,ou=people,dc=example,dc=com
 LDAP_PASS=YOUR-ADMIN-PASSWORD-HERE
 
 # A filter to use when searching for users
 # The user-provided user-name used to replace any occurrences of '${user}'
 # If you're setting this option via other means, such as within a docker-compose.yml,
-# you may need escape the $, often using $$ or \$ instead. 
+# you may need escape the $, often using $$ or \$ instead.
 LDAP_USER_FILTER=(&(uid=${user}))
 
 # Set the LDAP version to use when connecting to the server

--- a/example_configs/dolibarr.md
+++ b/example_configs/dolibarr.md
@@ -4,7 +4,7 @@ This example will help you to create user in dolibarr from your users in your ll
 
 ## To connect ldap->dolibarr 
 
-In Dolibarr, install the LDAP module from Home -> Modules/Applications
+In Dolibarr, install the LDAP module from `Home` -> `Modules/Applications`
 Go to the configuration of this module and fill it like this:
 
 
@@ -17,24 +17,23 @@ Go to the configuration of this module and fill it like this:
  - Server port: port `3890`
  - Server DN: `dc=example,dc=com`
  - Use TLS:  `No`
- - Administrator DN: `cn=admin,ou=people,dc=example,dc=com`
+ - Administrator DN: `uid=admin,ou=people,dc=example,dc=com`
  - Administrator password: `secret`
 
 Click on modify then "TEST LDAP CONNECTION". 
 You should get this result on the bottom:
 ```
  TCP connect to LDAP server successful (Server=ldap://example.com, Port=389)
-Connect/Authenticate to LDAP server successful (Server=ldap://example.com, Port=389, Admin=cn=admin,ou=people,dc=example,dc=com, Password=**********)
+Connect/Authenticate to LDAP server successful (Server=ldap://example.com, Port=389, Admin=uid=admin,ou=people,dc=example,dc=com, Password=**********)
 LDAP server configured for version 3
 ```
 
-And two new tabs will appear on the top:
-Users and Groups
+And two new tabs will appear on the top: `Users` and `Groups`.
 
-We will use only Users in this example to get the users we want to import.
-The tab Groups would be to import groups.
+We will use only `Users` in this example to get the users we want to import.
+The tab `Groups` would be to import groups.
 
-Click on the Users tab and fill it like this:
+Click on the `Users` tab and fill it like this:
  - Users' DN: `ou=people,dc=example,dc=com`
  - List of objectClass: `person`
  - Search filter: `memberOf=cn=yournamegroup,ou=groups,dc=example,dc=com`
@@ -47,20 +46,20 @@ Click on the Users tab and fill it like this:
  - Login `uid`
  - Email address `mail`
 
-Click on "MODIFY" and then on "TEST A LDAP SEARCH"
+Click on "MODIFY" and then on "TEST A LDAP SEARCH".
 
 You should get the number of users in the group or all users if you didn't use a filter.
 
 
 ## To import ldap users into the dolibarr database (needed to login with those users):
 
-Navigate to Users & Groups -> New Users
+Navigate to `Users & Groups` -> `New Users`. 
 Click on the blank form "Users in LDAP database", you will get the list of the users in the group filled above. With the "GET" button, you will import the selected user.
 
 
 ## To enable LDAP login:
 
-Modify your `conf.php` in your dolibarr folder in `htdocs/conf`
+Modify your `conf.php` in your dolibarr folder in `htdocs/conf`. 
 Replace
 ```
 // Authentication settings
@@ -76,9 +75,9 @@ $dolibarr_main_auth_ldap_host='ldap://127.0.0.1:3890';
 $dolibarr_main_auth_ldap_port='3890';
 $dolibarr_main_auth_ldap_version='3';
 $dolibarr_main_auth_ldap_servertype='openldap';
-$dolibarr_main_auth_ldap_login_attribute='cn';
+$dolibarr_main_auth_ldap_login_attribute='uid';
 $dolibarr_main_auth_ldap_dn='ou=people,dc=example,dc=com';
-$dolibarr_main_auth_ldap_admin_login='cn=admin,ou=people,dc=example,dc=com';
+$dolibarr_main_auth_ldap_admin_login='uid=admin,ou=people,dc=example,dc=com';
 $dolibarr_main_auth_ldap_admin_pass='secret';
 ```
 

--- a/example_configs/jellyfin.md
+++ b/example_configs/jellyfin.md
@@ -4,12 +4,24 @@ Replace `dc=example,dc=com` with your LLDAP configured domain.
 
 ### LDAP Bind User
 ```
-cn=admin,ou=people,dc=example,dc=com
+uid=admin,ou=people,dc=example,dc=com
 ```
 
 ### LDAP Base DN for searches
 ```
 ou=people,dc=example,dc=com
+```
+
+### LDAP Attributes
+
+```
+uid, mail
+```
+
+### LDAP Name Attribute
+
+```
+uid
 ```
 
 ### User Filter

--- a/example_configs/jitsi_meet.conf
+++ b/example_configs/jitsi_meet.conf
@@ -18,7 +18,7 @@ LDAP_URL=ldap://IP:3890
 LDAP_BASE=ou=people,dc=example,dc=com
 
 # LDAP user DN.
-LDAP_BINDDN=cn=admin,ou=people,dc=example,dc=com
+LDAP_BINDDN=uid=admin,ou=people,dc=example,dc=com
 
 # LLDAP admin password.
 LDAP_BINDPW=password

--- a/example_configs/keycloak.md
+++ b/example_configs/keycloak.md
@@ -25,7 +25,7 @@ The key settings are:
  - Connection URL: `ldap://<your-lldap-container>:3890`
  - Users DN: `ou=people,dc=example,dc=com` (or whatever `dc` you have)
  - Bind Type: `simple`
- - Bind DN: `cn=admin,ou=people,dc=example,dc=com` (replace with your admin user and `dc`)
+ - Bind DN: `uid=admin,ou=people,dc=example,dc=com` (replace with your admin user and `dc`)
  - Bind Credential: your LLDAP admin password
 
 Test the connection and authentication, it should work.

--- a/server/src/infra/ldap_handler.rs
+++ b/server/src/infra/ldap_handler.rs
@@ -80,7 +80,10 @@ fn get_user_id_from_distinguished_name(
         bail!("Not a subtree of the base tree");
     }
     if parts.len() == base_tree.len() + 2 {
-        if parts[1].0 != "ou" || parts[1].1 != "people" || parts[0].0 != "cn" {
+        if parts[1].0 != "ou"
+            || parts[1].1 != "people"
+            || (parts[0].0 != "cn" && parts[0].0 != "uid")
+        {
             bail!(
                 r#"Unexpected user DN format. Got "{}", expected: "cn=username,ou=people,{}""#,
                 dn,
@@ -803,7 +806,7 @@ mod tests {
             LdapHandler::new(mock, "dc=example,dc=com".to_string(), UserId::new("test"));
 
         let request = LdapOp::BindRequest(LdapBindRequest {
-            dn: "cn=bob,ou=people,dc=example,dc=com".to_string(),
+            dn: "uid=bob,ou=people,dc=example,dc=com".to_string(),
             cred: LdapBindCred::Simple("pass".to_string()),
         });
         assert_eq!(


### PR DESCRIPTION
This also changes the recommendation to use "uid" instead of "cn", since that's the meaning of the field. Using the actual value of "cn" will not actually work.