### PR TITLE
Introduce a read-only user

### DIFF
--- a/server/src/infra/graphql/mutation.rs
+++ b/server/src/infra/graphql/mutation.rs
@@ -63,7 +63,7 @@ impl<Handler: BackendHandler + Sync> Mutation<Handler> {
         context: &Context<Handler>,
         user: CreateUserInput,
     ) -> FieldResult<super::query::User<Handler>> {
-        if !context.validation_result.is_admin {
+        if !context.validation_result.is_admin() {
             return Err("Unauthorized user creation".into());
         }
         let user_id = UserId::new(&user.id);
@@ -88,7 +88,7 @@ impl<Handler: BackendHandler + Sync> Mutation<Handler> {
         context: &Context<Handler>,
         name: String,
     ) -> FieldResult<super::query::Group<Handler>> {
-        if !context.validation_result.is_admin {
+        if !context.validation_result.is_admin() {
             return Err("Unauthorized group creation".into());
         }
         let group_id = context.handler.create_group(&name).await?;
@@ -103,7 +103,7 @@ impl<Handler: BackendHandler + Sync> Mutation<Handler> {
         context: &Context<Handler>,
         user: UpdateUserInput,
     ) -> FieldResult<Success> {
-        if !context.validation_result.can_access(&user.id) {
+        if !context.validation_result.can_write(&user.id) {
             return Err("Unauthorized user update".into());
         }
         context
@@ -123,7 +123,7 @@ impl<Handler: BackendHandler + Sync> Mutation<Handler> {
         context: &Context<Handler>,
         group: UpdateGroupInput,
     ) -> FieldResult<Success> {
-        if !context.validation_result.is_admin {
+        if !context.validation_result.is_admin() {
             return Err("Unauthorized group update".into());
         }
         if group.id == 1 {
@@ -144,7 +144,7 @@ impl<Handler: BackendHandler + Sync> Mutation<Handler> {
         user_id: String,
         group_id: i32,
     ) -> FieldResult<Success> {
-        if !context.validation_result.is_admin {
+        if !context.validation_result.is_admin() {
             return Err("Unauthorized group membership modification".into());
         }
         context
@@ -159,7 +159,7 @@ impl<Handler: BackendHandler + Sync> Mutation<Handler> {
         user_id: String,
         group_id: i32,
     ) -> FieldResult<Success> {
-        if !context.validation_result.is_admin {
+        if !context.validation_result.is_admin() {
             return Err("Unauthorized group membership modification".into());
         }
         if context.validation_result.user == user_id && group_id == 1 {
@@ -173,7 +173,7 @@ impl<Handler: BackendHandler + Sync> Mutation<Handler> {
     }
 
     async fn delete_user(context: &Context<Handler>, user_id: String) -> FieldResult<Success> {
-        if !context.validation_result.is_admin {
+        if !context.validation_result.is_admin() {
             return Err("Unauthorized user deletion".into());
         }
         if context.validation_result.user == user_id {
@@ -184,7 +184,7 @@ impl<Handler: BackendHandler + Sync> Mutation<Handler> {
     }
 
     async fn delete_group(context: &Context<Handler>, group_id: i32) -> FieldResult<Success> {
-        if !context.validation_result.is_admin {
+        if !context.validation_result.is_admin() {
             return Err("Unauthorized group deletion".into());
         }
         if group_id == 1 {

--- a/server/src/infra/graphql/query.rs
+++ b/server/src/infra/graphql/query.rs
@@ -107,7 +107,7 @@ impl<Handler: BackendHandler + Sync> Query<Handler> {
     }
 
     pub async fn user(context: &Context<Handler>, user_id: String) -> FieldResult<User<Handler>> {
-        if !context.validation_result.can_access(&user_id) {
+        if !context.validation_result.can_read(&user_id) {
             return Err("Unauthorized access to user data".into());
         }
         Ok(context
@@ -121,7 +121,7 @@ impl<Handler: BackendHandler + Sync> Query<Handler> {
         context: &Context<Handler>,
         #[graphql(name = "where")] filters: Option<RequestFilter>,
     ) -> FieldResult<Vec<User<Handler>>> {
-        if !context.validation_result.is_admin {
+        if !context.validation_result.is_admin_or_readonly() {
             return Err("Unauthorized access to user list".into());
         }
         Ok(context
@@ -132,7 +132,7 @@ impl<Handler: BackendHandler + Sync> Query<Handler> {
     }
 
     async fn groups(context: &Context<Handler>) -> FieldResult<Vec<Group<Handler>>> {
-        if !context.validation_result.is_admin {
+        if !context.validation_result.is_admin_or_readonly() {
             return Err("Unauthorized access to group list".into());
         }
         Ok(context
@@ -143,7 +143,7 @@ impl<Handler: BackendHandler + Sync> Query<Handler> {
     }
 
     async fn group(context: &Context<Handler>, group_id: i32) -> FieldResult<Group<Handler>> {
-        if !context.validation_result.is_admin {
+        if !context.validation_result.is_admin_or_readonly() {
             return Err("Unauthorized access to group data".into());
         }
         Ok(context
@@ -234,7 +234,7 @@ impl<Handler: BackendHandler + Sync> Group<Handler> {
     }
     /// The groups to which this user belongs.
     async fn users(&self, context: &Context<Handler>) -> FieldResult<Vec<User<Handler>>> {
-        if !context.validation_result.is_admin {
+        if !context.validation_result.is_admin_or_readonly() {
             return Err("Unauthorized access to group data".into());
         }
         Ok(context


### PR DESCRIPTION
Fixes #176 .

This PR will create a group "lldap_readonly" on first run. Then the admin can create a user and add it to this group. It'll then be available both for web access (read-only except to update the details of the read-only user) and through LDAP (same, readonly except to change its own password).