### PR TITLE
Add filter by group

### DIFF
--- a/example_configs/portainer.md
+++ b/example_configs/portainer.md
@@ -20,6 +20,7 @@ uid=admin,ou=people,dc=example,dc=com
 xxx
 ```
 
+
 ## User search configurations
 ### Base DN
 ```
@@ -29,10 +30,15 @@ ou=people,dc=example,dc=com
 ```
 uid
 ```
-### Filter 
+### Filter (all available user)
 ```
 (objectClass=person)
 ```
+### Filter by groups (assuming you already create and manage the user into group, in this example the user already in lldap_portainer group)
+```
+(&(objectClass=person)(memberof=cn=lldap_portainer,ou=groups,dc=example,dc=com))
+```
+
 
 ## Group search configurations 
 ### Group Base DN

--- a/example_configs/portainer.md
+++ b/example_configs/portainer.md
@@ -1,55 +1,64 @@
-# Configuration for Portainer CE
-##  Settings > Authentication 
+# Configuration for Portainer CE/BE
+###  Settings > Authentication > LDAP > Custom
 ---
 
-## LDAP configuration 
-### LDAP Server
+## LDAP configuration
+
+#### LDAP Server
 ```
-localhost:3890
+localhost:3890 or ip-address:3890
 ```
-### Anonymous mode
+#### Anonymous mode
 ```
 off
 ```
-### Reader DN
+#### Reader DN
 ```
 uid=admin,ou=people,dc=example,dc=com
 ```
-### Password
+#### Password
 ```
 xxx
 ```
-
+* Password is the ENV you set at *LLDAP_LDAP_USER_PASS=* or `lldap_config.toml`
 
 ## User search configurations
-### Base DN
+
+#### Base DN
 ```
 ou=people,dc=example,dc=com
 ```
-### Username attribute
+#### Username attribute
 ```
 uid
 ```
-### Filter (all available user)
+### Filter
+#### All available user(s)
 ```
 (objectClass=person)
 ```
-### Filter by groups (assuming you already create and manage the user into group, in this example the user already in lldap_portainer group)
+* Using this filter will list all user registered in LLDAP
+
+#### All user(s) from specific group
 ```
 (&(objectClass=person)(memberof=cn=lldap_portainer,ou=groups,dc=example,dc=com))
 ```
+* Using this filter will only list user that included in `lldap_portainer` group. 
+* Admin should manually configure groups and add a user to it. **lldap_portainer** only sample.
+
 
 
 ## Group search configurations 
-### Group Base DN
+
+#### Group Base DN
 ```
 ou=groups,dc=example,dc=com
 ```
-### Group Membership Attribute
+#### Group Membership Attribute
 ```
 cn
 ```
-### Group Filter 
+#### Group Filter 
 ```
 is optional
 ```


### PR DESCRIPTION
Add User filter search by groups, as some safety practice to group the user and filter user available in that group, rather than querying all user in ldap.