### PR TITLE
Implement tracing logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1998,6 +1998,8 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-actix-web",
+ "tracing-attributes",
+ "tracing-forest",
  "tracing-log",
  "tracing-subscriber",
 ]
@@ -2091,6 +2093,15 @@ name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "matches"
@@ -2839,6 +2850,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3546,18 +3566,18 @@ checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
-version = "1.0.30"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
+checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.30"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3744,9 +3764,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.15"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42e6fa53307c8a17e4ccd4dc81cf5ec38db9209f59b222210375b54ee40d1e2"
+checksum = "cc6b8ad3567499f98a1db7a752b07a7c8c7c7c34c332ec00effb2b0027974b7c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3760,6 +3780,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "tracing-forest"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5db74d83f3fcda3ca1355dd91294098df02cc03d54e6cce81e40a18671c3fd7a"
+dependencies = [
+ "chrono",
+ "smallvec",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -3790,9 +3824,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80a4ddde70311d8da398062ecf6fc2c309337de6b0f77d6c27aff8d53f6fca52"
 dependencies = [
  "ansi_term",
+ "lazy_static",
+ "matchers",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/app/src/components/change_password.rs
+++ b/app/src/components/change_password.rs
@@ -211,8 +211,8 @@ impl Component for ChangePasswordForm {
         CommonComponentParts::<Self>::update(self, msg)
     }
 
-    fn change(&mut self, _: Self::Properties) -> ShouldRender {
-        false
+    fn change(&mut self, props: Self::Properties) -> ShouldRender {
+        self.common.change(props)
     }
 
     fn view(&self) -> Html {

--- a/app/src/components/create_group.rs
+++ b/app/src/components/create_group.rs
@@ -92,8 +92,8 @@ impl Component for CreateGroupForm {
         CommonComponentParts::<Self>::update(self, msg)
     }
 
-    fn change(&mut self, _: Self::Properties) -> ShouldRender {
-        false
+    fn change(&mut self, props: Self::Properties) -> ShouldRender {
+        self.common.change(props)
     }
 
     fn view(&self) -> Html {

--- a/app/src/components/create_user.rs
+++ b/app/src/components/create_user.rs
@@ -185,8 +185,8 @@ impl Component for CreateUserForm {
         CommonComponentParts::<Self>::update(self, msg)
     }
 
-    fn change(&mut self, _: Self::Properties) -> ShouldRender {
-        false
+    fn change(&mut self, props: Self::Properties) -> ShouldRender {
+        self.common.change(props)
     }
 
     fn view(&self) -> Html {

--- a/app/src/components/group_details.rs
+++ b/app/src/components/group_details.rs
@@ -190,8 +190,8 @@ impl Component for GroupDetails {
         CommonComponentParts::<Self>::update(self, msg)
     }
 
-    fn change(&mut self, _: Self::Properties) -> ShouldRender {
-        false
+    fn change(&mut self, props: Self::Properties) -> ShouldRender {
+        self.common.change(props)
     }
 
     fn view(&self) -> Html {

--- a/app/src/components/group_table.rs
+++ b/app/src/components/group_table.rs
@@ -75,8 +75,8 @@ impl Component for GroupTable {
         CommonComponentParts::<Self>::update(self, msg)
     }
 
-    fn change(&mut self, _: Self::Properties) -> ShouldRender {
-        false
+    fn change(&mut self, props: Self::Properties) -> ShouldRender {
+        self.common.change(props)
     }
 
     fn view(&self) -> Html {

--- a/app/src/components/login.rs
+++ b/app/src/components/login.rs
@@ -141,8 +141,8 @@ impl Component for LoginForm {
         CommonComponentParts::<Self>::update(self, msg)
     }
 
-    fn change(&mut self, _: Self::Properties) -> ShouldRender {
-        false
+    fn change(&mut self, props: Self::Properties) -> ShouldRender {
+        self.common.change(props)
     }
 
     fn view(&self) -> Html {

--- a/app/src/components/logout.rs
+++ b/app/src/components/logout.rs
@@ -55,8 +55,8 @@ impl Component for LogoutButton {
         CommonComponentParts::<Self>::update(self, msg)
     }
 
-    fn change(&mut self, _: Self::Properties) -> ShouldRender {
-        false
+    fn change(&mut self, props: Self::Properties) -> ShouldRender {
+        self.common.change(props)
     }
 
     fn view(&self) -> Html {

--- a/app/src/components/remove_user_from_group.rs
+++ b/app/src/components/remove_user_from_group.rs
@@ -81,8 +81,8 @@ impl Component for RemoveUserFromGroupComponent {
         )
     }
 
-    fn change(&mut self, _: Self::Properties) -> ShouldRender {
-        false
+    fn change(&mut self, props: Self::Properties) -> ShouldRender {
+        self.common.change(props)
     }
 
     fn view(&self) -> Html {

--- a/app/src/components/reset_password_step1.rs
+++ b/app/src/components/reset_password_step1.rs
@@ -76,8 +76,8 @@ impl Component for ResetPasswordStep1Form {
         CommonComponentParts::<Self>::update(self, msg)
     }
 
-    fn change(&mut self, _: Self::Properties) -> ShouldRender {
-        false
+    fn change(&mut self, props: Self::Properties) -> ShouldRender {
+        self.common.change(props)
     }
 
     fn view(&self) -> Html {

--- a/app/src/components/reset_password_step2.rs
+++ b/app/src/components/reset_password_step2.rs
@@ -145,8 +145,8 @@ impl Component for ResetPasswordStep2Form {
         CommonComponentParts::<Self>::update(self, msg)
     }
 
-    fn change(&mut self, _: Self::Properties) -> ShouldRender {
-        false
+    fn change(&mut self, props: Self::Properties) -> ShouldRender {
+        self.common.change(props)
     }
 
     fn view(&self) -> Html {

--- a/app/src/components/user_details.rs
+++ b/app/src/components/user_details.rs
@@ -185,8 +185,8 @@ impl Component for UserDetails {
         CommonComponentParts::<Self>::update(self, msg)
     }
 
-    fn change(&mut self, _: Self::Properties) -> ShouldRender {
-        false
+    fn change(&mut self, props: Self::Properties) -> ShouldRender {
+        self.common.change(props)
     }
 
     fn view(&self) -> Html {

--- a/app/src/components/user_details_form.rs
+++ b/app/src/components/user_details_form.rs
@@ -96,8 +96,8 @@ impl Component for UserDetailsForm {
         )
     }
 
-    fn change(&mut self, _: Self::Properties) -> ShouldRender {
-        false
+    fn change(&mut self, props: Self::Properties) -> ShouldRender {
+        self.common.change(props)
     }
 
     fn view(&self) -> Html {

--- a/app/src/components/user_table.rs
+++ b/app/src/components/user_table.rs
@@ -81,8 +81,8 @@ impl Component for UserTable {
         CommonComponentParts::<Self>::update(self, msg)
     }
 
-    fn change(&mut self, _: Self::Properties) -> ShouldRender {
-        false
+    fn change(&mut self, props: Self::Properties) -> ShouldRender {
+        self.common.change(props)
     }
 
     fn view(&self) -> Html {

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -41,10 +41,9 @@ tokio = { version = "1.13.1", features = ["full"] }
 tokio-native-tls = "0.3"
 tokio-util = "0.6.3"
 tokio-stream = "*"
-tracing = "*"
 tracing-actix-web = "0.4.0-beta.7"
+tracing-attributes = "^0.1.21"
 tracing-log = "*"
-tracing-subscriber = "0.3"
 rand = { version = "0.8", features = ["small_rng", "getrandom"] }
 juniper_actix = "0.4.0"
 juniper = "0.15.6"
@@ -52,6 +51,10 @@ itertools = "0.10.1"
 
 [dependencies.opaque-ke]
 version = "0.6"
+
+[dependencies.tracing-subscriber]
+version = "0.3"
+features = ["env-filter", "tracing-log"]
 
 [dependencies.lettre]
 version = "0.10.0-rc.3"
@@ -93,6 +96,13 @@ version = "*"
 
 [dependencies.openssl-sys]
 features = ["vendored"]
+version = "*"
+
+[dependencies.tracing-forest]
+features = ["smallvec", "chrono", "tokio"]
+version = "^0.1.4"
+
+[dependencies.tracing]
 version = "*"
 
 [dev-dependencies]

--- a/server/src/domain/sql_backend_handler.rs
+++ b/server/src/domain/sql_backend_handler.rs
@@ -602,24 +602,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_bind_admin() {
-        let sql_pool = get_in_memory_db().await;
-        let config = ConfigurationBuilder::default()
-            .ldap_user_dn(UserId::new("admin"))
-            .ldap_user_pass(secstr::SecUtf8::from("test"))
-            .build()
-            .unwrap();
-        let handler = SqlBackendHandler::new(config, sql_pool);
-        handler
-            .bind(BindRequest {
-                name: UserId::new("admin"),
-                password: "test".to_string(),
-            })
-            .await
-            .unwrap();
-    }
-
-    #[tokio::test]
     async fn test_bind_user() {
         let sql_pool = get_initialized_db().await;
         let config = get_default_config();

--- a/server/src/domain/sql_opaque_handler.rs
+++ b/server/src/domain/sql_opaque_handler.rs
@@ -90,17 +90,6 @@ impl SqlBackendHandler {
 impl LoginHandler for SqlBackendHandler {
     #[instrument(skip_all, level = "debug", err)]
     async fn bind(&self, request: BindRequest) -> Result<()> {
-        if request.name == self.config.ldap_user_dn {
-            if SecUtf8::from(request.password) == self.config.ldap_user_pass {
-                return Ok(());
-            } else {
-                debug!(r#"Invalid password for LDAP bind user"#);
-                return Err(DomainError::AuthenticationError(format!(
-                    " for user '{}'",
-                    request.name
-                )));
-            }
-        }
         let (query, values) = Query::select()
             .column(Users::PasswordHash)
             .from(Users::Table)

--- a/server/src/domain/sql_opaque_handler.rs
+++ b/server/src/domain/sql_opaque_handler.rs
@@ -7,14 +7,15 @@ use super::{
 };
 use async_trait::async_trait;
 use lldap_auth::opaque;
-use log::*;
 use sea_query::{Expr, Iden, Query};
 use sea_query_binder::SqlxBinder;
 use secstr::SecUtf8;
 use sqlx::Row;
+use tracing::{debug, instrument};
 
 type SqlOpaqueHandler = SqlBackendHandler;
 
+#[instrument(skip_all, level = "debug", err)]
 fn passwords_match(
     password_file_bytes: &[u8],
     clear_password: &str,
@@ -48,6 +49,7 @@ impl SqlBackendHandler {
         )?)
     }
 
+    #[instrument(skip_all, level = "debug", err)]
     async fn get_password_file_for_user(
         &self,
         username: &str,
@@ -86,6 +88,7 @@ impl SqlBackendHandler {
 
 #[async_trait]
 impl LoginHandler for SqlBackendHandler {
+    #[instrument(skip_all, level = "debug", err)]
     async fn bind(&self, request: BindRequest) -> Result<()> {
         if request.name == self.config.ldap_user_dn {
             if SecUtf8::from(request.password) == self.config.ldap_user_pass {
@@ -135,6 +138,7 @@ impl LoginHandler for SqlBackendHandler {
 
 #[async_trait]
 impl OpaqueHandler for SqlOpaqueHandler {
+    #[instrument(skip_all, level = "debug", err)]
     async fn login_start(
         &self,
         request: login::ClientLoginStartRequest,
@@ -163,6 +167,7 @@ impl OpaqueHandler for SqlOpaqueHandler {
         })
     }
 
+    #[instrument(skip_all, level = "debug", err)]
     async fn login_finish(&self, request: login::ClientLoginFinishRequest) -> Result<UserId> {
         let secret_key = self.get_orion_secret_key()?;
         let login::ServerData {
@@ -181,6 +186,7 @@ impl OpaqueHandler for SqlOpaqueHandler {
         Ok(UserId::new(&username))
     }
 
+    #[instrument(skip_all, level = "debug", err)]
     async fn registration_start(
         &self,
         request: registration::ClientRegistrationStartRequest,
@@ -202,6 +208,7 @@ impl OpaqueHandler for SqlOpaqueHandler {
         })
     }
 
+    #[instrument(skip_all, level = "debug", err)]
     async fn registration_finish(
         &self,
         request: registration::ClientRegistrationFinishRequest,
@@ -230,6 +237,7 @@ impl OpaqueHandler for SqlOpaqueHandler {
 }
 
 /// Convenience function to set a user's password.
+#[instrument(skip_all, level = "debug", err)]
 pub(crate) async fn register_password(
     opaque_handler: &SqlOpaqueHandler,
     username: &UserId,

--- a/server/src/infra/auth_service.rs
+++ b/server/src/infra/auth_service.rs
@@ -13,14 +13,14 @@ use actix_web_httpauth::extractors::bearer::BearerAuth;
 use anyhow::Result;
 use chrono::prelude::*;
 use futures::future::{ok, Ready};
-use futures_util::{FutureExt, TryFutureExt};
+use futures_util::FutureExt;
 use hmac::Hmac;
 use jwt::{SignWithKey, VerifyWithKey};
 use sha2::Sha512;
 use time::ext::NumericalDuration;
 use tracing::{debug, instrument, warn};
 
-use lldap_auth::{login, opaque, password_reset, registration, JWTClaims};
+use lldap_auth::{login, password_reset, registration, JWTClaims};
 
 use crate::{
     domain::{
@@ -30,7 +30,7 @@ use crate::{
     },
     infra::{
         tcp_backend_handler::*,
-        tcp_server::{error_to_http_response, AppState},
+        tcp_server::{error_to_http_response, AppState, TcpError, TcpResult},
     },
 };
 
@@ -51,9 +51,9 @@ fn create_jwt(key: &Hmac<Sha512>, user: String, groups: HashSet<GroupIdAndName>)
     jwt::Token::new(header, claims).sign_with_key(key).unwrap()
 }
 
-fn parse_refresh_token(token: &str) -> std::result::Result<(u64, UserId), HttpResponse> {
+fn parse_refresh_token(token: &str) -> TcpResult<(u64, UserId)> {
     match token.split_once('+') {
-        None => Err(HttpResponse::Unauthorized().body("Invalid refresh token")),
+        None => Err(DomainError::AuthenticationError("Invalid refresh token".to_string()).into()),
         Some((token, u)) => {
             let refresh_token_hash = {
                 let mut s = DefaultHasher::new();
@@ -65,14 +65,16 @@ fn parse_refresh_token(token: &str) -> std::result::Result<(u64, UserId), HttpRe
     }
 }
 
-fn get_refresh_token(request: HttpRequest) -> std::result::Result<(u64, UserId), HttpResponse> {
+fn get_refresh_token(request: HttpRequest) -> TcpResult<(u64, UserId)> {
     match (
         request.cookie("refresh_token"),
         request.headers().get("refresh-token"),
     ) {
         (Some(c), _) => parse_refresh_token(c.value()),
         (_, Some(t)) => parse_refresh_token(t.to_str().unwrap()),
-        (None, None) => Err(HttpResponse::Unauthorized().body("Missing refresh token")),
+        (None, None) => {
+            Err(DomainError::AuthenticationError("Missing refresh token".to_string()).into())
+        }
     }
 }
 
@@ -80,68 +82,75 @@ fn get_refresh_token(request: HttpRequest) -> std::result::Result<(u64, UserId),
 async fn get_refresh<Backend>(
     data: web::Data<AppState<Backend>>,
     request: HttpRequest,
-) -> HttpResponse
+) -> TcpResult<HttpResponse>
 where
     Backend: TcpBackendHandler + BackendHandler + 'static,
 {
     let backend_handler = &data.backend_handler;
     let jwt_key = &data.jwt_key;
-    let (refresh_token_hash, user) = match get_refresh_token(request) {
-        Ok(t) => t,
-        Err(http_response) => return http_response,
-    };
-    let res_found = data
+    let (refresh_token_hash, user) = get_refresh_token(request)?;
+    let found = data
         .backend_handler
         .check_token(refresh_token_hash, &user)
-        .await;
-    // Async closures are not supported yet.
-    match res_found {
-        Ok(true) => backend_handler.get_user_groups(&user).await,
-        Ok(false) => Err(DomainError::AuthenticationError(
+        .await?;
+    if !found {
+        return Err(TcpError::DomainError(DomainError::AuthenticationError(
             "Invalid refresh token".to_string(),
-        )),
-        Err(e) => Err(e),
+        )));
     }
-    .map(|groups| create_jwt(jwt_key, user.to_string(), groups))
-    .map(|token| {
-        HttpResponse::Ok()
-            .cookie(
-                Cookie::build("token", token.as_str())
-                    .max_age(1.days())
-                    .path("/")
-                    .http_only(true)
-                    .same_site(SameSite::Strict)
-                    .finish(),
-            )
-            .json(&login::ServerLoginResponse {
-                token: token.as_str().to_owned(),
-                refresh_token: None,
-            })
-    })
-    .unwrap_or_else(error_to_http_response)
+    Ok(backend_handler
+        .get_user_groups(&user)
+        .await
+        .map(|groups| create_jwt(jwt_key, user.to_string(), groups))
+        .map(|token| {
+            HttpResponse::Ok()
+                .cookie(
+                    Cookie::build("token", token.as_str())
+                        .max_age(1.days())
+                        .path("/")
+                        .http_only(true)
+                        .same_site(SameSite::Strict)
+                        .finish(),
+                )
+                .json(&login::ServerLoginResponse {
+                    token: token.as_str().to_owned(),
+                    refresh_token: None,
+                })
+        })?)
 }
 
-#[instrument(skip_all, level = "debug")]
-async fn get_password_reset_step1<Backend>(
+async fn get_refresh_handler<Backend>(
     data: web::Data<AppState<Backend>>,
     request: HttpRequest,
 ) -> HttpResponse
 where
     Backend: TcpBackendHandler + BackendHandler + 'static,
 {
+    get_refresh(data, request)
+        .await
+        .unwrap_or_else(error_to_http_response)
+}
+
+#[instrument(skip_all, level = "debug")]
+async fn get_password_reset_step1<Backend>(
+    data: web::Data<AppState<Backend>>,
+    request: HttpRequest,
+) -> TcpResult<()>
+where
+    Backend: TcpBackendHandler + BackendHandler + 'static,
+{
     let user_id = match request.match_info().get("user_id") {
-        None => return HttpResponse::BadRequest().body("Missing user ID"),
+        None => return Err(TcpError::BadRequest("Missing user ID".to_string())),
         Some(id) => UserId::new(id),
     };
-    let token = match data.backend_handler.start_password_reset(&user_id).await {
-        Err(e) => return HttpResponse::InternalServerError().body(e.to_string()),
-        Ok(None) => return HttpResponse::Ok().finish(),
-        Ok(Some(token)) => token,
+    let token = match data.backend_handler.start_password_reset(&user_id).await? {
+        None => return Ok(()),
+        Some(token) => token,
     };
     let user = match data.backend_handler.get_user_details(&user_id).await {
         Err(e) => {
             warn!("Error getting used details: {:#?}", e);
-            return HttpResponse::Ok().finish();
+            return Ok(());
         }
         Ok(u) => u,
     };
@@ -153,38 +162,50 @@ where
         &data.mail_options,
     ) {
         warn!("Error sending email: {:#?}", e);
-        return HttpResponse::InternalServerError().body(format!("Could not send email: {}", e));
+        return Err(TcpError::InternalServerError(format!(
+            "Could not send email: {}",
+            e
+        )));
     }
-    HttpResponse::Ok().finish()
+    Ok(())
 }
 
-#[instrument(skip_all, level = "debug")]
-async fn get_password_reset_step2<Backend>(
+async fn get_password_reset_step1_handler<Backend>(
     data: web::Data<AppState<Backend>>,
     request: HttpRequest,
 ) -> HttpResponse
 where
     Backend: TcpBackendHandler + BackendHandler + 'static,
 {
-    let token = match request.match_info().get("token") {
-        None => return HttpResponse::BadRequest().body("Missing token"),
-        Some(token) => token,
-    };
-    let user_id = match data
+    get_password_reset_step1(data, request)
+        .await
+        .map(|()| HttpResponse::Ok().finish())
+        .unwrap_or_else(error_to_http_response)
+}
+
+#[instrument(skip_all, level = "debug")]
+async fn get_password_reset_step2<Backend>(
+    data: web::Data<AppState<Backend>>,
+    request: HttpRequest,
+) -> TcpResult<HttpResponse>
+where
+    Backend: TcpBackendHandler + BackendHandler + 'static,
+{
+    let token = request
+        .match_info()
+        .get("token")
+        .ok_or_else(|| TcpError::BadRequest("Missing reset token".to_string()))?;
+    let user_id = data
         .backend_handler
         .get_user_id_for_password_reset_token(token)
-        .await
-    {
-        Err(_) => return HttpResponse::Unauthorized().body("Invalid or expired token"),
-        Ok(user_id) => user_id,
-    };
+        .await?;
     let _ = data
         .backend_handler
         .delete_password_reset_token(token)
         .await;
     let groups = HashSet::new();
     let token = create_jwt(&data.jwt_key, user_id.to_string(), groups);
-    HttpResponse::Ok()
+    Ok(HttpResponse::Ok()
         .cookie(
             Cookie::build("token", token.as_str())
                 .max_age(5.minutes())
@@ -197,44 +218,39 @@ where
         .json(&password_reset::ServerPasswordResetResponse {
             user_id: user_id.to_string(),
             token: token.as_str().to_owned(),
-        })
+        }))
 }
 
-#[instrument(skip_all, level = "debug")]
-async fn get_logout<Backend>(
+async fn get_password_reset_step2_handler<Backend>(
     data: web::Data<AppState<Backend>>,
     request: HttpRequest,
 ) -> HttpResponse
 where
     Backend: TcpBackendHandler + BackendHandler + 'static,
 {
-    let (refresh_token_hash, user) = match get_refresh_token(request) {
-        Ok(t) => t,
-        Err(http_response) => return http_response,
-    };
-    if let Err(response) = data
-        .backend_handler
+    get_password_reset_step2(data, request)
+        .await
+        .unwrap_or_else(error_to_http_response)
+}
+
+#[instrument(skip_all, level = "debug")]
+async fn get_logout<Backend>(
+    data: web::Data<AppState<Backend>>,
+    request: HttpRequest,
+) -> TcpResult<HttpResponse>
+where
+    Backend: TcpBackendHandler + BackendHandler + 'static,
+{
+    let (refresh_token_hash, user) = get_refresh_token(request)?;
+    data.backend_handler
         .delete_refresh_token(refresh_token_hash)
-        .map_err(error_to_http_response)
-        .await
-    {
-        return response;
-    };
-    match data
-        .backend_handler
-        .blacklist_jwts(&user)
-        .map_err(error_to_http_response)
-        .await
-    {
-        Ok(new_blacklisted_jwts) => {
-            let mut jwt_blacklist = data.jwt_blacklist.write().unwrap();
-            for jwt in new_blacklisted_jwts {
-                jwt_blacklist.insert(jwt);
-            }
-        }
-        Err(response) => return response,
-    };
-    HttpResponse::Ok()
+        .await?;
+    let new_blacklisted_jwts = data.backend_handler.blacklist_jwts(&user).await?;
+    let mut jwt_blacklist = data.jwt_blacklist.write().unwrap();
+    for jwt in new_blacklisted_jwts {
+        jwt_blacklist.insert(jwt);
+    }
+    Ok(HttpResponse::Ok()
         .cookie(
             Cookie::build("token", "")
                 .max_age(0.days())
@@ -251,11 +267,23 @@ where
                 .same_site(SameSite::Strict)
                 .finish(),
         )
-        .finish()
+        .finish())
 }
 
-pub(crate) fn error_to_api_response<T>(error: DomainError) -> ApiResult<T> {
-    ApiResult::Right(error_to_http_response(error))
+async fn get_logout_handler<Backend>(
+    data: web::Data<AppState<Backend>>,
+    request: HttpRequest,
+) -> HttpResponse
+where
+    Backend: TcpBackendHandler + BackendHandler + 'static,
+{
+    get_logout(data, request)
+        .await
+        .unwrap_or_else(error_to_http_response)
+}
+
+pub(crate) fn error_to_api_response<T, E: Into<TcpError>>(error: E) -> ApiResult<T> {
+    ApiResult::Right(error_to_http_response(error.into()))
 }
 
 pub type ApiResult<M> = actix_web::Either<web::Json<M>, HttpResponse>;
@@ -279,131 +307,120 @@ where
 async fn get_login_successful_response<Backend>(
     data: &web::Data<AppState<Backend>>,
     name: &UserId,
-) -> HttpResponse
+) -> TcpResult<HttpResponse>
 where
     Backend: TcpBackendHandler + BackendHandler,
 {
     // The authentication was successful, we need to fetch the groups to create the JWT
     // token.
-    data.backend_handler
-        .get_user_groups(name)
-        .and_then(|g| async { Ok((g, data.backend_handler.create_refresh_token(name).await?)) })
-        .await
-        .map(|(groups, (refresh_token, max_age))| {
-            let token = create_jwt(&data.jwt_key, name.to_string(), groups);
-            let refresh_token_plus_name = refresh_token + "+" + name.as_str();
+    let groups = data.backend_handler.get_user_groups(name).await?;
+    let (refresh_token, max_age) = data.backend_handler.create_refresh_token(name).await?;
+    let token = create_jwt(&data.jwt_key, name.to_string(), groups);
+    let refresh_token_plus_name = refresh_token + "+" + name.as_str();
 
-            HttpResponse::Ok()
-                .cookie(
-                    Cookie::build("token", token.as_str())
-                        .max_age(1.days())
-                        .path("/")
-                        .http_only(true)
-                        .same_site(SameSite::Strict)
-                        .finish(),
-                )
-                .cookie(
-                    Cookie::build("refresh_token", refresh_token_plus_name.clone())
-                        .max_age(max_age.num_days().days())
-                        .path("/auth")
-                        .http_only(true)
-                        .same_site(SameSite::Strict)
-                        .finish(),
-                )
-                .json(&login::ServerLoginResponse {
-                    token: token.as_str().to_owned(),
-                    refresh_token: Some(refresh_token_plus_name),
-                })
-        })
-        .unwrap_or_else(error_to_http_response)
+    Ok(HttpResponse::Ok()
+        .cookie(
+            Cookie::build("token", token.as_str())
+                .max_age(1.days())
+                .path("/")
+                .http_only(true)
+                .same_site(SameSite::Strict)
+                .finish(),
+        )
+        .cookie(
+            Cookie::build("refresh_token", refresh_token_plus_name.clone())
+                .max_age(max_age.num_days().days())
+                .path("/auth")
+                .http_only(true)
+                .same_site(SameSite::Strict)
+                .finish(),
+        )
+        .json(&login::ServerLoginResponse {
+            token: token.as_str().to_owned(),
+            refresh_token: Some(refresh_token_plus_name),
+        }))
 }
 
 #[instrument(skip_all, level = "debug")]
 async fn opaque_login_finish<Backend>(
     data: web::Data<AppState<Backend>>,
     request: web::Json<login::ClientLoginFinishRequest>,
+) -> TcpResult<HttpResponse>
+where
+    Backend: TcpBackendHandler + BackendHandler + OpaqueHandler + 'static,
+{
+    let name = data
+        .backend_handler
+        .login_finish(request.into_inner())
+        .await?;
+    get_login_successful_response(&data, &name).await
+}
+
+async fn opaque_login_finish_handler<Backend>(
+    data: web::Data<AppState<Backend>>,
+    request: web::Json<login::ClientLoginFinishRequest>,
 ) -> HttpResponse
 where
     Backend: TcpBackendHandler + BackendHandler + OpaqueHandler + 'static,
 {
-    let name = match data
-        .backend_handler
-        .login_finish(request.into_inner())
+    opaque_login_finish(data, request)
         .await
-    {
-        Ok(n) => n,
-        Err(e) => return error_to_http_response(e),
-    };
-    get_login_successful_response(&data, &name).await
+        .unwrap_or_else(error_to_http_response)
 }
 
 #[instrument(skip_all, level = "debug")]
 async fn simple_login<Backend>(
     data: web::Data<AppState<Backend>>,
     request: web::Json<login::ClientSimpleLoginRequest>,
+) -> TcpResult<HttpResponse>
+where
+    Backend: TcpBackendHandler + BackendHandler + OpaqueHandler + LoginHandler + 'static,
+{
+    let user_id = UserId::new(&request.username);
+    let bind_request = BindRequest {
+        name: user_id.clone(),
+        password: request.password.clone(),
+    };
+    data.backend_handler.bind(bind_request).await?;
+    get_login_successful_response(&data, &user_id).await
+}
+
+async fn simple_login_handler<Backend>(
+    data: web::Data<AppState<Backend>>,
+    request: web::Json<login::ClientSimpleLoginRequest>,
 ) -> HttpResponse
 where
-    Backend: TcpBackendHandler + BackendHandler + OpaqueHandler + 'static,
+    Backend: TcpBackendHandler + BackendHandler + OpaqueHandler + LoginHandler + 'static,
 {
-    let password = &request.password;
-    let mut rng = rand::rngs::OsRng;
-    let opaque::client::login::ClientLoginStartResult { state, message } =
-        match opaque::client::login::start_login(password, &mut rng) {
-            Ok(n) => n,
-            Err(e) => {
-                return HttpResponse::InternalServerError()
-                    .body(format!("Internal Server Error: {:#?}", e))
-            }
-        };
-
-    let username = request.username.clone();
-    let start_request = login::ClientLoginStartRequest {
-        username: username.clone(),
-        login_start_request: message,
-    };
-
-    let start_response = match data.backend_handler.login_start(start_request).await {
-        Ok(n) => n,
-        Err(e) => return error_to_http_response(e),
-    };
-
-    let login_finish =
-        match opaque::client::login::finish_login(state, start_response.credential_response) {
-            Err(_) => {
-                return error_to_http_response(DomainError::AuthenticationError(String::from(
-                    "Invalid username or password",
-                )))
-            }
-            Ok(l) => l,
-        };
-
-    let finish_request = login::ClientLoginFinishRequest {
-        server_data: start_response.server_data,
-        credential_finalization: login_finish.message,
-    };
-
-    let name = match data.backend_handler.login_finish(finish_request).await {
-        Ok(n) => n,
-        Err(e) => return error_to_http_response(e),
-    };
-
-    get_login_successful_response(&data, &name).await
+    simple_login(data, request)
+        .await
+        .unwrap_or_else(error_to_http_response)
 }
 
 #[instrument(skip_all, level = "debug")]
 async fn post_authorize<Backend>(
     data: web::Data<AppState<Backend>>,
     request: web::Json<BindRequest>,
-) -> HttpResponse
+) -> TcpResult<HttpResponse>
 where
     Backend: TcpBackendHandler + BackendHandler + LoginHandler + 'static,
 {
     let name = request.name.clone();
     debug!(%name);
-    if let Err(e) = data.backend_handler.bind(request.into_inner()).await {
-        return error_to_http_response(e);
-    }
+    data.backend_handler.bind(request.into_inner()).await?;
     get_login_successful_response(&data, &name).await
+}
+
+async fn post_authorize_handler<Backend>(
+    data: web::Data<AppState<Backend>>,
+    request: web::Json<BindRequest>,
+) -> HttpResponse
+where
+    Backend: TcpBackendHandler + BackendHandler + LoginHandler + 'static,
+{
+    post_authorize(data, request)
+        .await
+        .unwrap_or_else(error_to_http_response)
 }
 
 #[instrument(skip_all, level = "debug")]
@@ -411,46 +428,47 @@ async fn opaque_register_start<Backend>(
     request: actix_web::HttpRequest,
     mut payload: actix_web::web::Payload,
     data: web::Data<AppState<Backend>>,
-) -> ApiResult<registration::ServerRegistrationStartResponse>
+) -> TcpResult<registration::ServerRegistrationStartResponse>
 where
     Backend: OpaqueHandler + 'static,
 {
     use actix_web::FromRequest;
-    let validation_result = match BearerAuth::from_request(&request, &mut payload.0)
+    let validation_result = BearerAuth::from_request(&request, &mut payload.0)
         .await
         .ok()
         .and_then(|bearer| check_if_token_is_valid(&data, bearer.token()).ok())
-    {
-        Some(t) => t,
-        None => {
-            return ApiResult::Right(
-                HttpResponse::Unauthorized().body("Not authorized to change the user's password"),
-            )
-        }
-    };
+        .ok_or_else(|| {
+            TcpError::UnauthorizedError("Not authorized to change the user's password".to_string())
+        })?;
     let registration_start_request =
-        match web::Json::<registration::ClientRegistrationStartRequest>::from_request(
+        web::Json::<registration::ClientRegistrationStartRequest>::from_request(
             &request,
             &mut payload.0,
         )
         .await
-        {
-            Ok(r) => r,
-            Err(e) => {
-                return ApiResult::Right(
-                    HttpResponse::BadRequest().body(format!("Bad request: {:#?}", e)),
-                )
-            }
-        }
+        .map_err(|e| TcpError::BadRequest(format!("{:#?}", e)))?
         .into_inner();
     let user_id = &registration_start_request.username;
     if !validation_result.can_write(user_id) {
-        return ApiResult::Right(
-            HttpResponse::Unauthorized().body("Not authorized to change the user's password"),
-        );
+        return Err(TcpError::UnauthorizedError(
+            "Not authorized to change the user's password".to_string(),
+        ));
     }
-    data.backend_handler
+    Ok(data
+        .backend_handler
         .registration_start(registration_start_request)
+        .await?)
+}
+
+async fn opaque_register_start_handler<Backend>(
+    request: actix_web::HttpRequest,
+    payload: actix_web::web::Payload,
+    data: web::Data<AppState<Backend>>,
+) -> ApiResult<registration::ServerRegistrationStartResponse>
+where
+    Backend: OpaqueHandler + 'static,
+{
+    opaque_register_start(request, payload, data)
         .await
         .map(|res| ApiResult::Left(web::Json(res)))
         .unwrap_or_else(error_to_api_response)
@@ -460,18 +478,26 @@ where
 async fn opaque_register_finish<Backend>(
     data: web::Data<AppState<Backend>>,
     request: web::Json<registration::ClientRegistrationFinishRequest>,
+) -> TcpResult<HttpResponse>
+where
+    Backend: TcpBackendHandler + BackendHandler + OpaqueHandler + 'static,
+{
+    data.backend_handler
+        .registration_finish(request.into_inner())
+        .await?;
+    Ok(HttpResponse::Ok().finish())
+}
+
+async fn opaque_register_finish_handler<Backend>(
+    data: web::Data<AppState<Backend>>,
+    request: web::Json<registration::ClientRegistrationFinishRequest>,
 ) -> HttpResponse
 where
     Backend: TcpBackendHandler + BackendHandler + OpaqueHandler + 'static,
 {
-    if let Err(e) = data
-        .backend_handler
-        .registration_finish(request.into_inner())
+    opaque_register_finish(data, request)
         .await
-    {
-        return error_to_http_response(e);
-    }
-    HttpResponse::Ok().finish()
+        .unwrap_or_else(error_to_http_response)
 }
 
 pub struct CookieToHeaderTranslatorFactory;
@@ -616,35 +642,38 @@ pub fn configure_server<Backend>(cfg: &mut web::ServiceConfig)
 where
     Backend: TcpBackendHandler + LoginHandler + OpaqueHandler + BackendHandler + 'static,
 {
-    cfg.service(web::resource("").route(web::post().to(post_authorize::<Backend>)))
+    cfg.service(web::resource("").route(web::post().to(post_authorize_handler::<Backend>)))
         .service(
             web::resource("/opaque/login/start")
                 .route(web::post().to(opaque_login_start::<Backend>)),
         )
         .service(
             web::resource("/opaque/login/finish")
-                .route(web::post().to(opaque_login_finish::<Backend>)),
+                .route(web::post().to(opaque_login_finish_handler::<Backend>)),
         )
-        .service(web::resource("/simple/login").route(web::post().to(simple_login::<Backend>)))
-        .service(web::resource("/refresh").route(web::get().to(get_refresh::<Backend>)))
+        .service(
+            web::resource("/simple/login").route(web::post().to(simple_login_handler::<Backend>)),
+        )
+        .service(web::resource("/refresh").route(web::get().to(get_refresh_handler::<Backend>)))
         .service(
             web::resource("/reset/step1/{user_id}")
-                .route(web::get().to(get_password_reset_step1::<Backend>)),
+                .route(web::get().to(get_password_reset_step1_handler::<Backend>)),
         )
         .service(
             web::resource("/reset/step2/{token}")
-                .route(web::get().to(get_password_reset_step2::<Backend>)),
+                .route(web::get().to(get_password_reset_step2_handler::<Backend>)),
         )
-        .service(web::resource("/logout").route(web::get().to(get_logout::<Backend>)))
+        .service(web::resource("/logout").route(web::get().to(get_logout_handler::<Backend>)))
         .service(
             web::scope("/opaque/register")
                 .wrap(CookieToHeaderTranslatorFactory)
                 .service(
-                    web::resource("/start").route(web::post().to(opaque_register_start::<Backend>)),
+                    web::resource("/start")
+                        .route(web::post().to(opaque_register_start_handler::<Backend>)),
                 )
                 .service(
                     web::resource("/finish")
-                        .route(web::post().to(opaque_register_finish::<Backend>)),
+                        .route(web::post().to(opaque_register_finish_handler::<Backend>)),
                 ),
         );
 }

--- a/server/src/infra/ldap_handler.rs
+++ b/server/src/infra/ldap_handler.rs
@@ -894,7 +894,7 @@ impl<Backend: BackendHandler + LoginHandler + OpaqueHandler> LdapHandler<Backend
                     .collect::<Result<_>>()?,
             )),
             LdapFilter::Not(filter) => Ok(GroupRequestFilter::Not(Box::new(
-                self.convert_group_filter(&*filter)?,
+                self.convert_group_filter(filter)?,
             ))),
             LdapFilter::Present(field) => {
                 if ALL_GROUP_ATTRIBUTE_KEYS.contains(&field.to_ascii_lowercase().as_str()) {
@@ -924,7 +924,7 @@ impl<Backend: BackendHandler + LoginHandler + OpaqueHandler> LdapHandler<Backend
                     .collect::<Result<_>>()?,
             )),
             LdapFilter::Not(filter) => Ok(UserRequestFilter::Not(Box::new(
-                self.convert_user_filter(&*filter)?,
+                self.convert_user_filter(filter)?,
             ))),
             LdapFilter::Equality(field, value) => {
                 let field = &field.to_ascii_lowercase();

--- a/server/src/infra/mail.rs
+++ b/server/src/infra/mail.rs
@@ -4,7 +4,7 @@ use lettre::{
     message::Mailbox, transport::smtp::authentication::Credentials, Message, SmtpTransport,
     Transport,
 };
-use log::debug;
+use tracing::debug;
 
 fn send_email(to: Mailbox, subject: &str, body: String, options: &MailOptions) -> Result<()> {
     let from = options

--- a/server/src/infra/sql_backend_handler.rs
+++ b/server/src/infra/sql_backend_handler.rs
@@ -6,6 +6,7 @@ use sea_query::{Expr, Iden, Query, SimpleExpr};
 use sea_query_binder::SqlxBinder;
 use sqlx::{query_as_with, query_with, Row};
 use std::collections::HashSet;
+use tracing::{debug, instrument};
 
 fn gen_random_string(len: usize) -> String {
     use rand::{distributions::Alphanumeric, rngs::SmallRng, Rng, SeedableRng};
@@ -19,12 +20,14 @@ fn gen_random_string(len: usize) -> String {
 
 #[async_trait]
 impl TcpBackendHandler for SqlBackendHandler {
+    #[instrument(skip_all, level = "debug")]
     async fn get_jwt_blacklist(&self) -> anyhow::Result<HashSet<u64>> {
         let (query, values) = Query::select()
             .column(JwtStorage::JwtHash)
             .from(JwtStorage::Table)
             .build_sqlx(DbQueryBuilder {});
 
+        debug!(%query);
         query_with(&query, values)
             .map(|row: DbRow| row.get::<i64, _>(&*JwtStorage::JwtHash.to_string()) as u64)
             .fetch(&self.sql_pool)
@@ -35,7 +38,9 @@ impl TcpBackendHandler for SqlBackendHandler {
             .map_err(|e| anyhow::anyhow!(e))
     }
 
+    #[instrument(skip_all, level = "debug")]
     async fn create_refresh_token(&self, user: &UserId) -> Result<(String, chrono::Duration)> {
+        debug!(?user);
         use std::collections::hash_map::DefaultHasher;
         use std::hash::{Hash, Hasher};
         // TODO: Initialize the rng only once. Maybe Arc<Cell>?
@@ -59,23 +64,30 @@ impl TcpBackendHandler for SqlBackendHandler {
                 (chrono::Utc::now() + duration).naive_utc().into(),
             ])
             .build_sqlx(DbQueryBuilder {});
+        debug!(%query);
         query_with(&query, values).execute(&self.sql_pool).await?;
         Ok((refresh_token, duration))
     }
 
+    #[instrument(skip_all, level = "debug")]
     async fn check_token(&self, refresh_token_hash: u64, user: &UserId) -> Result<bool> {
+        debug!(?user);
         let (query, values) = Query::select()
             .expr(SimpleExpr::Value(1.into()))
             .from(JwtRefreshStorage::Table)
             .and_where(Expr::col(JwtRefreshStorage::RefreshTokenHash).eq(refresh_token_hash as i64))
             .and_where(Expr::col(JwtRefreshStorage::UserId).eq(user))
             .build_sqlx(DbQueryBuilder {});
+        debug!(%query);
         Ok(query_with(&query, values)
             .fetch_optional(&self.sql_pool)
             .await?
             .is_some())
     }
+
+    #[instrument(skip_all, level = "debug")]
     async fn blacklist_jwts(&self, user: &UserId) -> Result<HashSet<u64>> {
+        debug!(?user);
         use sqlx::Result;
         let (query, values) = Query::select()
             .column(JwtStorage::JwtHash)
@@ -95,31 +107,39 @@ impl TcpBackendHandler for SqlBackendHandler {
             .values(vec![(JwtStorage::Blacklisted, true.into())])
             .and_where(Expr::col(JwtStorage::UserId).eq(user))
             .build_sqlx(DbQueryBuilder {});
+        debug!(%query);
         query_with(&query, values).execute(&self.sql_pool).await?;
         Ok(result?)
     }
+
+    #[instrument(skip_all, level = "debug")]
     async fn delete_refresh_token(&self, refresh_token_hash: u64) -> Result<()> {
         let (query, values) = Query::delete()
             .from_table(JwtRefreshStorage::Table)
-            .and_where(Expr::col(JwtRefreshStorage::RefreshTokenHash).eq(refresh_token_hash))
+            .and_where(Expr::col(JwtRefreshStorage::RefreshTokenHash).eq(refresh_token_hash as i64))
             .build_sqlx(DbQueryBuilder {});
+        debug!(%query);
         query_with(&query, values).execute(&self.sql_pool).await?;
         Ok(())
     }
 
+    #[instrument(skip_all, level = "debug")]
     async fn start_password_reset(&self, user: &UserId) -> Result<Option<String>> {
+        debug!(?user);
         let (query, values) = Query::select()
             .column(Users::UserId)
             .from(Users::Table)
             .and_where(Expr::col(Users::UserId).eq(user))
             .build_sqlx(DbQueryBuilder {});
 
+        debug!(%query);
         // Check that the user exists.
         if query_with(&query, values)
             .fetch_one(&self.sql_pool)
             .await
             .is_err()
         {
+            debug!("User not found");
             return Ok(None);
         }
 
@@ -139,10 +159,12 @@ impl TcpBackendHandler for SqlBackendHandler {
                 (chrono::Utc::now() + duration).naive_utc().into(),
             ])
             .build_sqlx(DbQueryBuilder {});
+        debug!(%query);
         query_with(&query, values).execute(&self.sql_pool).await?;
         Ok(Some(token))
     }
 
+    #[instrument(skip_all, level = "debug", ret)]
     async fn get_user_id_for_password_reset_token(&self, token: &str) -> Result<UserId> {
         let (query, values) = Query::select()
             .column(PasswordResetTokens::UserId)
@@ -152,6 +174,7 @@ impl TcpBackendHandler for SqlBackendHandler {
                 Expr::col(PasswordResetTokens::ExpiryDate).gt(chrono::Utc::now().naive_utc()),
             )
             .build_sqlx(DbQueryBuilder {});
+        debug!(%query);
 
         let (user_id,) = query_as_with(&query, values)
             .fetch_one(&self.sql_pool)
@@ -159,11 +182,13 @@ impl TcpBackendHandler for SqlBackendHandler {
         Ok(user_id)
     }
 
+    #[instrument(skip_all, level = "debug")]
     async fn delete_password_reset_token(&self, token: &str) -> Result<()> {
         let (query, values) = Query::delete()
             .from_table(PasswordResetTokens::Table)
             .and_where(Expr::col(PasswordResetTokens::Token).eq(token))
             .build_sqlx(DbQueryBuilder {});
+        debug!(%query);
         query_with(&query, values).execute(&self.sql_pool).await?;
         Ok(())
     }

--- a/server/src/infra/tcp_server.rs
+++ b/server/src/infra/tcp_server.rs
@@ -7,6 +7,7 @@ use crate::{
     infra::{
         auth_service,
         configuration::{Configuration, MailOptions},
+        logging::CustomRootSpanBuilder,
         tcp_backend_handler::*,
     },
 };
@@ -21,6 +22,7 @@ use sha2::Sha512;
 use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::RwLock;
+use tracing::info;
 
 async fn index() -> actix_web::Result<NamedFile> {
     let mut path = PathBuf::new();
@@ -105,6 +107,7 @@ where
         .context("while getting the jwt blacklist")?;
     let server_url = config.http_url.clone();
     let mail_options = config.smtp_options.clone();
+    info!("Starting the API/web server on port {}", config.http_port);
     server_builder
         .bind("http", ("0.0.0.0", config.http_port), move || {
             let backend_handler = backend_handler.clone();
@@ -114,16 +117,18 @@ where
             let mail_options = mail_options.clone();
             HttpServiceBuilder::new()
                 .finish(map_config(
-                    App::new().configure(move |cfg| {
-                        http_config(
-                            cfg,
-                            backend_handler,
-                            jwt_secret,
-                            jwt_blacklist,
-                            server_url,
-                            mail_options,
-                        )
-                    }),
+                    App::new()
+                        .wrap(tracing_actix_web::TracingLogger::<CustomRootSpanBuilder>::new())
+                        .configure(move |cfg| {
+                            http_config(
+                                cfg,
+                                backend_handler,
+                                jwt_secret,
+                                jwt_blacklist,
+                                server_url,
+                                mail_options,
+                            )
+                        }),
                     |_| AppConfig::default(),
                 ))
                 .tcp()


### PR DESCRIPTION
This PR instruments the code to add tracing events everywhere relevant. The events are then printed as a tree by tracing-forest, leading to a much-improved debug experience.

Fixes #17 