### PR TITLE
Update Authelia config for Authelia 4.36.1

### DIFF
--- a/example_configs/authelia_config.yml
+++ b/example_configs/authelia_config.yml
@@ -43,6 +43,6 @@ authentication_backend:
     display_name_attribute: displayName
     # The username and password of the admin user.
     # "admin" should be the admin username you set in the LLDAP configuration
-    user: cn=admin,ou=people,dc=example,dc=com
+    user: uid=admin,ou=people,dc=example,dc=com
     # Password can also be set using a secret: https://www.authelia.com/docs/configuration/secrets.html
     password: 'REPLACE_ME'

--- a/example_configs/authelia_config.yml
+++ b/example_configs/authelia_config.yml
@@ -7,7 +7,8 @@
 
 authentication_backend:
   # Password reset through authelia works normally.
-  disable_reset_password: false
+  password_reset:
+    disable: false
   # How often authelia should check if there is an user update in LDAP
   refresh_interval: 1m
   ldap:
@@ -42,6 +43,6 @@ authentication_backend:
     display_name_attribute: displayName
     # The username and password of the admin user.
     # "admin" should be the admin username you set in the LLDAP configuration
-    user: uid=admin,ou=people,dc=example,dc=com
+    user: cn=admin,ou=people,dc=example,dc=com
     # Password can also be set using a secret: https://www.authelia.com/docs/configuration/secrets.html
     password: 'REPLACE_ME'


### PR DESCRIPTION
Authelia 4.36.1 changed the key for password resets. Fixed an error where the user: field was incorrectly set to uid=admin, resulting in a fatal error starting Authelia.