### PR TITLE
Volume support

### DIFF
--- a/.github/workflows/Dockerfile.ci
+++ b/.github/workflows/Dockerfile.ci
@@ -59,9 +59,11 @@ RUN apt update && \
     apt install -y --no-install-recommends tini ca-certificates gosu && \
     apt clean && \
     rm -rf /var/lib/apt/lists/* && \
-    groupadd -g $GID $USER && useradd --system -m -g $USER --uid $UID $USER
+    groupadd -g $GID $USER && useradd --system -m -g $USER --uid $UID $USER && \
+    mkdir -p /data && chown $USER:$USER /data
 COPY --from=lldap --chown=$CONTAINERUSER:$CONTAINERUSER /lldap /app
 COPY --from=lldap --chown=$CONTAINERUSER:$CONTAINERUSER /docker-entrypoint.sh /docker-entrypoint.sh
+VOLUME ["/data"]
 WORKDIR /app
 ENTRYPOINT ["tini", "--", "/docker-entrypoint.sh"]
 CMD ["run", "--config-file", "/data/lldap_config.toml"]

--- a/.github/workflows/Dockerfile.ci.alpine
+++ b/.github/workflows/Dockerfile.ci.alpine
@@ -66,9 +66,12 @@ RUN echo http://mirror.math.princeton.edu/pub/alpinelinux/edge/testing/ >> /etc/
     --ingroup "$USER" \
     --no-create-home \
     --uid "$UID" \
-    "$USER"
+    "$USER" && \
+    mkdir -p /data && \
+    chown $USER:$USER /data
 COPY --from=lldap --chown=$CONTAINERUSER:$CONTAINERUSER /lldap /app
 COPY --from=lldap --chown=$CONTAINERUSER:$CONTAINERUSER /docker-entrypoint.sh /docker-entrypoint.sh
+VOLUME ["/data"]
 WORKDIR /app
 ENTRYPOINT ["tini", "--", "/docker-entrypoint.sh"]
 CMD ["run", "--config-file", "/data/lldap_config.toml"]


### PR DESCRIPTION
Add volume to enable volume use case correctly.
```
    volumes:
        - lldap_data:/data 
```

As `/data` is empty by default, `lldap_config.toml` will be copied over. We can also use predefined `lldap_config` if needed, should we?