### PR TITLE
Set admin email from config

### DIFF
--- a/lldap_config.docker_template.toml
+++ b/lldap_config.docker_template.toml
@@ -45,6 +45,11 @@
 ## For the administration interface, this is the username.
 #ldap_user_dn = "admin"
 
+## Admin email.
+## Email for the admin account. It is only used when initially creating
+## the admin user, and can safely be omitted.
+#ldap_user_email = "admin@example.com"
+
 ## Admin password.
 ## Password for the admin account, both for the LDAP bind and for the
 ## administration interface. It is only used when initially creating

--- a/server/src/infra/configuration.rs
+++ b/server/src/infra/configuration.rs
@@ -71,6 +71,8 @@ pub struct Configuration {
     pub ldap_base_dn: String,
     #[builder(default = r#"UserId::new("admin")"#)]
     pub ldap_user_dn: UserId,
+    #[builder(default = r#"String::default()"#)]
+    pub ldap_user_email: String,
     #[builder(default = r#"SecUtf8::from("password")"#)]
     pub ldap_user_pass: SecUtf8,
     #[builder(default = r#"String::from("sqlite://users.db?mode=rwc")"#)]

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -30,6 +30,7 @@ async fn create_admin_user(handler: &SqlBackendHandler, config: &Configuration) 
     handler
         .create_user(CreateUserRequest {
             user_id: config.ldap_user_dn.clone(),
+            email: config.ldap_user_email.clone(),
             display_name: Some("Administrator".to_string()),
             ..Default::default()
         })


### PR DESCRIPTION
Allows folks to set `ldap_user_email` alongside `ldap_user_dn` and `ldap_user_pass` via the configuration file / environment variables. I need to have my admin account provisioned with an email at creation, so this ends up being pretty useful :)

I'm having issues with building a Docker image / the linker (on Debian). but I don't think due to my changes? Please let me know if I've forgotten anything!