### PR TITLE
 Add UUID and creation date to the frontend

### DIFF
--- a/app/queries/get_group_details.graphql
+++ b/app/queries/get_group_details.graphql
@@ -3,6 +3,7 @@ query GetGroupDetails($id: Int!) {
     id
     displayName
     creationDate
+    uuid
     users {
       id
       displayName

--- a/app/queries/get_group_details.graphql
+++ b/app/queries/get_group_details.graphql
@@ -2,6 +2,7 @@ query GetGroupDetails($id: Int!) {
   group(groupId: $id) {
     id
     displayName
+    creationDate
     users {
       id
       displayName

--- a/app/queries/get_group_list.graphql
+++ b/app/queries/get_group_list.graphql
@@ -2,5 +2,6 @@ query GetGroupList {
   groups {
     id
     displayName
+    creationDate
   }
 }

--- a/app/queries/get_user_details.graphql
+++ b/app/queries/get_user_details.graphql
@@ -6,6 +6,7 @@ query GetUserDetails($id: String!) {
     firstName
     lastName
     creationDate
+    uuid
     groups {
       id
       displayName

--- a/app/src/components/group_details.rs
+++ b/app/src/components/group_details.rs
@@ -92,6 +92,15 @@ impl GroupDetails {
                   <span id="creationDate" class="form-constrol-static">{g.creation_date.date().naive_local()}</span>
                 </div>
               </div>
+              <div class="form-group row mb-3">
+                <label for="uuid"
+                  class="form-label col-4 col-form-label">
+                  {"UUID: "}
+                </label>
+                <div class="col-8">
+                  <span id="uuid" class="form-constrol-static">{g.uuid.to_string()}</span>
+                </div>
+              </div>
             </form>
           </div>
         </>

--- a/app/src/components/group_details.rs
+++ b/app/src/components/group_details.rs
@@ -69,42 +69,42 @@ impl GroupDetails {
     }
 
     fn view_details(&self, g: &Group) -> Html {
-      html! {
-        <>
-          <h3>{g.display_name.to_string()}</h3>
-          <div class="py-3">
-            <form class="form">
-              <div class="form-group row mb-3">
-                <label for="displayName"
-                  class="form-label col-4 col-form-label">
-                  {"Group: "}
-                </label>
-                <div class="col-8">
-                  <span id="groupId" class="form-constrol-static">{g.display_name.to_string()}</span>
+        html! {
+          <>
+            <h3>{g.display_name.to_string()}</h3>
+            <div class="py-3">
+              <form class="form">
+                <div class="form-group row mb-3">
+                  <label for="displayName"
+                    class="form-label col-4 col-form-label">
+                    {"Group: "}
+                  </label>
+                  <div class="col-8">
+                    <span id="groupId" class="form-constrol-static">{g.display_name.to_string()}</span>
+                  </div>
                 </div>
-              </div>
-              <div class="form-group row mb-3">
-                <label for="creationDate"
-                  class="form-label col-4 col-form-label">
-                  {"Creation date: "}
-                </label>
-                <div class="col-8">
-                  <span id="creationDate" class="form-constrol-static">{g.creation_date.date().naive_local()}</span>
+                <div class="form-group row mb-3">
+                  <label for="creationDate"
+                    class="form-label col-4 col-form-label">
+                    {"Creation date: "}
+                  </label>
+                  <div class="col-8">
+                    <span id="creationDate" class="form-constrol-static">{g.creation_date.date().naive_local()}</span>
+                  </div>
                 </div>
-              </div>
-              <div class="form-group row mb-3">
-                <label for="uuid"
-                  class="form-label col-4 col-form-label">
-                  {"UUID: "}
-                </label>
-                <div class="col-8">
-                  <span id="uuid" class="form-constrol-static">{g.uuid.to_string()}</span>
+                <div class="form-group row mb-3">
+                  <label for="uuid"
+                    class="form-label col-4 col-form-label">
+                    {"UUID: "}
+                  </label>
+                  <div class="col-8">
+                    <span id="uuid" class="form-constrol-static">{g.uuid.to_string()}</span>
+                  </div>
                 </div>
-              </div>
-            </form>
-          </div>
-        </>
-      }
+              </form>
+            </div>
+          </>
+        }
     }
 
     fn view_user_list(&self, g: &Group) -> Html {

--- a/app/src/components/group_details.rs
+++ b/app/src/components/group_details.rs
@@ -68,6 +68,36 @@ impl GroupDetails {
         }
     }
 
+    fn view_details(&self, g: &Group) -> Html {
+      html! {
+        <>
+          <h3>{g.display_name.to_string()}</h3>
+          <div class="py-3">
+            <form class="form">
+              <div class="form-group row mb-3">
+                <label for="displayName"
+                  class="form-label col-4 col-form-label">
+                  {"Group: "}
+                </label>
+                <div class="col-8">
+                  <span id="groupId" class="form-constrol-static">{g.display_name.to_string()}</span>
+                </div>
+              </div>
+              <div class="form-group row mb-3">
+                <label for="creationDate"
+                  class="form-label col-4 col-form-label">
+                  {"Creation date: "}
+                </label>
+                <div class="col-8">
+                  <span id="creationDate" class="form-constrol-static">{g.creation_date.date().naive_local()}</span>
+                </div>
+              </div>
+            </form>
+          </div>
+        </>
+      }
+    }
+
     fn view_user_list(&self, g: &Group) -> Html {
         let make_user_row = |user: &User| {
             let user_id = user.id.clone();
@@ -92,7 +122,6 @@ impl GroupDetails {
         };
         html! {
           <>
-            <h3>{g.display_name.to_string()}</h3>
             <h5 class="fw-bold">{"Members"}</h5>
             <div class="table-responsive">
               <table class="table table-striped">
@@ -201,6 +230,7 @@ impl Component for GroupDetails {
             (Some(u), error) => {
                 html! {
                     <div>
+                      {self.view_details(u)}
                       {self.view_user_list(u)}
                       {self.view_add_user_button(u)}
                       {self.view_messages(error)}

--- a/app/src/components/group_table.rs
+++ b/app/src/components/group_table.rs
@@ -97,7 +97,8 @@ impl GroupTable {
                   <table class="table table-striped">
                     <thead>
                       <tr>
-                        <th>{"Groups"}</th>
+                        <th>{"Group name"}</th>
+                        <th>{"Creation date"}</th>
                         <th>{"Delete"}</th>
                       </tr>
                     </thead>
@@ -121,6 +122,9 @@ impl GroupTable {
                 <Link route=AppRoute::GroupDetails(group.id)>
                   {&group.display_name}
                 </Link>
+              </td>
+              <td>
+                {&group.creation_date.date().naive_local()}
               </td>
               <td>
                 <DeleteGroup

--- a/app/src/components/user_details_form.rs
+++ b/app/src/components/user_details_form.rs
@@ -195,6 +195,15 @@ impl Component for UserDetailsForm {
                   <span id="creationDate" class="form-constrol-static">{&self.common.user.creation_date.date().naive_local()}</span>
                 </div>
               </div>
+              <div class="form-group row mb-3">
+                <label for="uuid"
+                class="form-label col-4 col-form-label">
+                {"UUID: "}
+                </label>
+                <div class="col-8">
+                  <span id="creationDate" class="form-constrol-static">{&self.common.user.uuid}</span>
+                </div>
+              </div>
               <div class="form-group row justify-content-center">
                 <button
                   type="submit"
@@ -267,6 +276,7 @@ impl UserDetailsForm {
                     first_name: model.first_name,
                     last_name: model.last_name,
                     creation_date: self.common.user.creation_date,
+                    uuid: self.common.user.uuid.clone(),
                     groups: self.common.user.groups.clone(),
                 };
                 self.just_updated = true;

--- a/schema.graphql
+++ b/schema.graphql
@@ -18,6 +18,7 @@ type Group {
   id: Int!
   displayName: String!
   creationDate: DateTimeUtc!
+  uuid: String!
   "The groups to which this user belongs."
   users: [User!]!
 }
@@ -68,6 +69,7 @@ type User {
   firstName: String!
   lastName: String!
   creationDate: DateTimeUtc!
+  uuid: String!
   "The groups to which this user belongs."
   groups: [Group!]!
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -17,6 +17,7 @@ type Mutation {
 type Group {
   id: Int!
   displayName: String!
+  creationDate: DateTimeUtc!
   "The groups to which this user belongs."
   users: [User!]!
 }

--- a/server/src/infra/graphql/query.rs
+++ b/server/src/infra/graphql/query.rs
@@ -363,8 +363,12 @@ mod tests {
           user(userId: "bob") {
             id
             email
+            creationDate
+            uuid
             groups {
               id
+              creationDate
+              uuid
             }
           }
         }"#;
@@ -376,6 +380,8 @@ mod tests {
                 Ok(DomainUser {
                     user_id: UserId::new("bob"),
                     email: "bob@bobbers.on".to_string(),
+                    creation_date: chrono::Utc.timestamp_millis(42),
+                    uuid: crate::uuid!("b1a2a3a4b1b2c1c2d1d2d3d4d5d6d7d8"),
                     ..Default::default()
                 })
             });
@@ -404,7 +410,13 @@ mod tests {
                     "user": {
                         "id": "bob",
                         "email": "bob@bobbers.on",
-                        "groups": [{"id": 3}]
+                        "creationDate": "1970-01-01T00:00:00.042+00:00",
+                        "uuid": "b1a2a3a4-b1b2-c1c2-d1d2-d3d4d5d6d7d8",
+                        "groups": [{
+                            "id": 3,
+                            "creationDate": "1970-01-01T00:00:00.000000042+00:00",
+                            "uuid": "a1a2a3a4-b1b2-c1c2-d1d2-d3d4d5d6d7d8"
+                        }]
                     }
                 }),
                 vec![]

--- a/server/src/infra/graphql/query.rs
+++ b/server/src/infra/graphql/query.rs
@@ -221,6 +221,10 @@ impl<Handler: BackendHandler + Sync> User<Handler> {
         self.user.creation_date
     }
 
+    fn uuid(&self) -> &str {
+        self.user.uuid.as_str()
+    }
+
     /// The groups to which this user belongs.
     async fn groups(&self, context: &Context<Handler>) -> FieldResult<Vec<Group<Handler>>> {
         let span = debug_span!("[GraphQL query] user::groups");
@@ -260,6 +264,7 @@ pub struct Group<Handler: BackendHandler> {
     group_id: i32,
     display_name: String,
     creation_date: chrono::DateTime<chrono::Utc>,
+    uuid: String,
     members: Option<Vec<String>>,
     _phantom: std::marker::PhantomData<Box<Handler>>,
 }
@@ -274,6 +279,9 @@ impl<Handler: BackendHandler + Sync> Group<Handler> {
     }
     fn creation_date(&self) -> chrono::DateTime<chrono::Utc> {
         self.creation_date
+    }
+    fn uuid(&self) -> String {
+        self.uuid.clone()
     }
     /// The groups to which this user belongs.
     async fn users(&self, context: &Context<Handler>) -> FieldResult<Vec<User<Handler>>> {
@@ -303,6 +311,7 @@ impl<Handler: BackendHandler> From<GroupDetails> for Group<Handler> {
             group_id: group_details.group_id.0,
             display_name: group_details.display_name,
             creation_date: group_details.creation_date,
+            uuid: group_details.uuid.into_string(),
             members: None,
             _phantom: std::marker::PhantomData,
         }
@@ -315,6 +324,7 @@ impl<Handler: BackendHandler> From<DomainGroup> for Group<Handler> {
             group_id: group.id.0,
             display_name: group.display_name,
             creation_date: group.creation_date,
+            uuid: group.uuid.into_string(),
             members: Some(group.users.into_iter().map(UserId::into_string).collect()),
             _phantom: std::marker::PhantomData,
         }

--- a/server/src/infra/graphql/query.rs
+++ b/server/src/infra/graphql/query.rs
@@ -272,6 +272,9 @@ impl<Handler: BackendHandler + Sync> Group<Handler> {
     fn display_name(&self) -> String {
         self.display_name.clone()
     }
+    fn creation_date(&self) -> chrono::DateTime<chrono::Utc> {
+        self.creation_date
+    }
     /// The groups to which this user belongs.
     async fn users(&self, context: &Context<Handler>) -> FieldResult<Vec<User<Handler>>> {
         let span = debug_span!("[GraphQL query] group::users");


### PR DESCRIPTION
These changes implement #211.

- UUID is added to the details view of users and groups.
- creation date is added as a column to the list of groups and to the groups detail view.

To do this I have added read only fields to the group details view using the same format that the user detail view has. 