### PR TITLE
Fix: Change input filed to password type in change_password ui

### DIFF
--- a/app/src/components/change_password.rs
+++ b/app/src/components/change_password.rs
@@ -252,6 +252,7 @@ impl Component for ChangePasswordForm {
                   <Field
                     form=&self.form
                     field_name="password"
+                    input_type="password"
                     class="form-control"
                     class_invalid="is-invalid has-error"
                     class_valid="has-success"
@@ -271,6 +272,7 @@ impl Component for ChangePasswordForm {
                   <Field
                     form=&self.form
                     field_name="confirm_password"
+                    input_type="password"
                     class="form-control"
                     class_invalid="is-invalid has-error"
                     class_valid="has-success"


### PR DESCRIPTION
The change password UI shows a password because the input field is "text" type.

In this PR, I tried to fix it by adding `input_type="password"` at `<Field />`.
