### PR TITLE
server: Add support for users' avatars in GrahpQL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2159,6 +2159,7 @@ name = "lldap_app"
 version = "0.4.0"
 dependencies = [
  "anyhow",
+ "base64",
  "chrono",
  "graphql_client 0.10.0",
  "http",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -599,6 +599,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
 
 [[package]]
+name = "bytemuck"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5377c8865e74a160d21f29c2d40669f53286db6eab59b88540cbb12ffc8b835"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -694,6 +700,12 @@ checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
+
+[[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "combine"
@@ -1785,6 +1797,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb56e1aa765b4b4f3aadfab769793b7087bb03a4ea4920644a6d238e2df5b9ed"
 
 [[package]]
+name = "image"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e30ca2ecf7666107ff827a8e481de6a132a9b687ed3bb20bb1c144a36c00964"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+ "color_quant",
+ "jpeg-decoder",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1845,6 +1871,12 @@ checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "jpeg-decoder"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9478aa10f73e7528198d75109c8be5cd7d15fb530238040148d5f9a22d4c5b3b"
 
 [[package]]
 name = "js-sys"
@@ -2128,6 +2160,7 @@ dependencies = [
  "chrono",
  "graphql_client 0.10.0",
  "http",
+ "image",
  "indexmap",
  "jwt",
  "lldap_auth",
@@ -2442,6 +2475,17 @@ name = "num-iter"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+dependencies = [
+ "autocfg 1.1.0",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
 dependencies = [
  "autocfg 1.1.0",
  "num-integer",
@@ -4559,7 +4603,7 @@ dependencies = [
 [[package]]
 name = "yew_form"
 version = "0.1.8"
-source = "git+https://github.com/sassman/yew_form/?rev=67050812695b7a8a90b81b0637e347fc6629daed#67050812695b7a8a90b81b0637e347fc6629daed"
+source = "git+https://github.com/jfbilodeau/yew_form?rev=67050812695b7a8a90b81b0637e347fc6629daed#67050812695b7a8a90b81b0637e347fc6629daed"
 dependencies = [
  "validator",
  "validator_derive",
@@ -4569,7 +4613,7 @@ dependencies = [
 [[package]]
 name = "yew_form_derive"
 version = "0.1.8"
-source = "git+https://github.com/sassman/yew_form/?rev=67050812695b7a8a90b81b0637e347fc6629daed#67050812695b7a8a90b81b0637e347fc6629daed"
+source = "git+https://github.com/jfbilodeau/yew_form?rev=67050812695b7a8a90b81b0637e347fc6629daed#67050812695b7a8a90b81b0637e347fc6629daed"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2115,6 +2115,7 @@ dependencies = [
  "futures-util",
  "hmac 0.10.1",
  "http",
+ "image",
  "itertools",
  "juniper",
  "juniper_actix",
@@ -2133,6 +2134,7 @@ dependencies = [
  "sea-query-binder",
  "secstr",
  "serde",
+ "serde_bytes",
  "serde_json",
  "sha2",
  "sqlx",
@@ -3315,6 +3317,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfc50e8183eeeb6178dcb167ae34a8051d63535023ae38b5d8d12beae193d37b"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2009,14 +2009,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "ldap3_server"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7873d5bd5baabdb77aa2d8a762bf8b1136f9f90cc90f44639b4c0d4486281dcb"
+name = "ldap3_proto"
+version = "0.2.3"
+source = "git+https://github.com/nitnelave/ldap3_server/?rev=7b50b2b82c383f5f70e02e11072bb916629ed2bc#7b50b2b82c383f5f70e02e11072bb916629ed2bc"
 dependencies = [
  "bytes",
  "lber",
- "tokio-util 0.6.10",
+ "tokio-util 0.7.3",
+ "tracing",
 ]
 
 [[package]]
@@ -2120,7 +2120,7 @@ dependencies = [
  "juniper",
  "juniper_actix",
  "jwt",
- "ldap3_server",
+ "ldap3_proto",
  "lettre",
  "lldap_auth",
  "log",
@@ -2144,7 +2144,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.23.4",
  "tokio-stream",
- "tokio-util 0.6.10",
+ "tokio-util 0.7.3",
  "tracing",
  "tracing-actix-web",
  "tracing-attributes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2278,6 +2278,7 @@ name = "migration-tool"
 version = "0.3.0-alpha.1"
 dependencies = [
  "anyhow",
+ "base64",
  "graphql_client 0.11.0",
  "ldap3",
  "lldap_auth",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,8 @@ members = [
 ]
 
 default-members = ["server"]
+
+# Remove once https://github.com/kanidm/ldap3_proto/pull/8 is merged.
+[patch.crates-io.ldap3_proto]
+git = 'https://github.com/nitnelave/ldap3_server/'
+rev = '7b50b2b82c383f5f70e02e11072bb916629ed2bc'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,12 +7,3 @@ members = [
 ]
 
 default-members = ["server"]
-
-# TODO: remove when there's a new release.
-[patch.crates-io.yew_form]
-git = 'https://github.com/sassman/yew_form/'
-rev = '67050812695b7a8a90b81b0637e347fc6629daed'
-
-[patch.crates-io.yew_form_derive]
-git = 'https://github.com/sassman/yew_form/'
-rev = '67050812695b7a8a90b81b0637e347fc6629daed'

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -18,8 +18,6 @@ wasm-bindgen = "0.2"
 yew = "0.18"
 yewtil = "*"
 yew-router = "0.15"
-yew_form = "0.1.8"
-yew_form_derive = "*"
 
 # Needed because of https://github.com/tkaitchuck/aHash/issues/95
 indexmap = "=1.6.2"
@@ -46,6 +44,19 @@ features = [
 [dependencies.lldap_auth]
 path = "../auth"
 features = [ "opaque_client" ]
+
+[dependencies.image]
+features = ["jpeg"]
+default-features = false
+version = "0.24"
+
+[dependencies.yew_form]
+git = "https://github.com/jfbilodeau/yew_form"
+rev = "67050812695b7a8a90b81b0637e347fc6629daed"
+
+[dependencies.yew_form_derive]
+git = "https://github.com/jfbilodeau/yew_form"
+rev = "67050812695b7a8a90b81b0637e347fc6629daed"
 
 [lib]
 crate-type = ["cdylib"]

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1"
+base64 = "0.13"
 graphql_client = "0.10"
 http = "0.2"
 jwt = "0.13"
@@ -27,6 +28,7 @@ version = "0.3"
 features = [
   "Document",
   "Element",
+  "FileReader",
   "HtmlDocument",
   "HtmlInputElement",
   "HtmlOptionElement",

--- a/app/queries/get_user_details.graphql
+++ b/app/queries/get_user_details.graphql
@@ -5,6 +5,7 @@ query GetUserDetails($id: String!) {
     displayName
     firstName
     lastName
+    avatar
     creationDate
     uuid
     groups {

--- a/app/src/components/create_user.rs
+++ b/app/src/components/create_user.rs
@@ -90,6 +90,7 @@ impl CommonComponent<CreateUserForm> for CreateUserForm {
                         displayName: to_option(model.display_name),
                         firstName: to_option(model.first_name),
                         lastName: to_option(model.last_name),
+                        avatar: None,
                     },
                 };
                 self.common.call_graphql::<CreateUser, _>(

--- a/app/src/components/user_details.rs
+++ b/app/src/components/user_details.rs
@@ -198,8 +198,7 @@ impl Component for UserDetails {
                   <>
                     <h3>{u.id.to_string()}</h3>
                     <UserDetailsForm
-                      user=u.clone()
-                      on_error=self.common.callback(Msg::OnError)/>
+                      user=u.clone() />
                     <div class="row justify-content-center">
                       <NavButton
                         route=AppRoute::ChangePassword(u.id.clone())

--- a/app/src/components/user_details_form.rs
+++ b/app/src/components/user_details_form.rs
@@ -234,6 +234,7 @@ impl UserDetailsForm {
             displayName: None,
             firstName: None,
             lastName: None,
+            avatar: None,
         };
         let default_user_input = user_input.clone();
         let model = self.form.model();

--- a/migration-tool/Cargo.toml
+++ b/migration-tool/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Valentin Tolmer <valentin@tolmer.fr>"]
 
 [dependencies]
 anyhow = "*"
+base64 = "0.13"
 rand = "0.8"
 requestty = "0.4.1"
 serde = "1"

--- a/migration-tool/src/lldap.rs
+++ b/migration-tool/src/lldap.rs
@@ -70,23 +70,12 @@ pub struct User {
 impl User {
     // https://github.com/graphql-rust/graphql-client/issues/386
     pub fn new(
-        id: String,
-        email: String,
-        display_name: Option<String>,
-        first_name: Option<String>,
-        last_name: Option<String>,
+        user_input: create_user::CreateUserInput,
         password: Option<String>,
         dn: String,
     ) -> User {
         User {
-            user_input: create_user::CreateUserInput {
-                id,
-                email,
-                display_name,
-                first_name,
-                last_name,
-                avatar: None,
-            },
+            user_input,
             password,
             dn,
         }
@@ -102,6 +91,8 @@ impl User {
     custom_scalars_module = "crate::infra::graphql"
 )]
 struct CreateUser;
+
+pub type CreateUserInput = create_user::CreateUserInput;
 
 #[derive(GraphQLQuery)]
 #[graphql(

--- a/migration-tool/src/lldap.rs
+++ b/migration-tool/src/lldap.rs
@@ -85,6 +85,7 @@ impl User {
                 display_name,
                 first_name,
                 last_name,
+                avatar: None,
             },
             password,
             dn,

--- a/schema.graphql
+++ b/schema.graphql
@@ -60,6 +60,7 @@ input CreateUserInput {
   displayName: String
   firstName: String
   lastName: String
+  avatar: String
 }
 
 type User {
@@ -68,6 +69,7 @@ type User {
   displayName: String!
   firstName: String!
   lastName: String!
+  avatar: String!
   creationDate: DateTimeUtc!
   uuid: String!
   "The groups to which this user belongs."
@@ -85,6 +87,7 @@ input UpdateUserInput {
   displayName: String
   firstName: String
   lastName: String
+  avatar: String
 }
 
 schema {

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -45,6 +45,7 @@ tracing-actix-web = "0.4.0-beta.7"
 tracing-attributes = "^0.1.21"
 tracing-log = "*"
 rustls-pemfile = "1.0.0"
+serde_bytes = "0.11.7"
 
 [dependencies.chrono]
 features = ["serde"]
@@ -116,6 +117,11 @@ version = "^0.1.4"
 [dependencies.actix-tls]
 features = ["default", "rustls"]
 version = "=3.0.0-beta.5"
+
+[dependencies.image]
+features = ["jpeg"]
+default-features = false
+version = "0.24"
 
 [dev-dependencies]
 mockall = "0.9.1"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -27,7 +27,7 @@ itertools = "0.10.1"
 juniper = "0.15.10"
 juniper_actix = "0.4.0"
 jwt = "0.13"
-ldap3_server = "=0.1.11"
+ldap3_proto = "*"
 log = "*"
 orion = "0.16"
 rustls = "0.20"
@@ -39,7 +39,7 @@ thiserror = "*"
 time = "0.2"
 tokio-rustls = "0.23"
 tokio-stream = "*"
-tokio-util = "0.6.3"
+tokio-util = "0.7.3"
 tracing = "*"
 tracing-actix-web = "0.4.0-beta.7"
 tracing-attributes = "^0.1.21"
@@ -104,7 +104,7 @@ version = "*"
 
 [dependencies.tokio]
 features = ["full"]
-version = "1.13.1"
+version = "1.17"
 
 [dependencies.uuid]
 features = ["v3"]

--- a/server/src/domain/handler.rs
+++ b/server/src/domain/handler.rs
@@ -126,6 +126,11 @@ impl From<&JpegPhoto> for String {
 }
 
 impl JpegPhoto {
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.0
+    }
+
+    #[cfg(test)]
     pub fn for_tests() -> Self {
         use image::{ImageOutputFormat, Rgb, RgbImage};
         let img = RgbImage::from_fn(32, 32, |x, y| {

--- a/server/src/domain/sql_backend_handler.rs
+++ b/server/src/domain/sql_backend_handler.rs
@@ -367,6 +367,7 @@ impl BackendHandler for SqlBackendHandler {
             Users::DisplayName,
             Users::FirstName,
             Users::LastName,
+            Users::Avatar,
             Users::CreationDate,
             Users::Uuid,
         ];
@@ -378,6 +379,7 @@ impl BackendHandler for SqlBackendHandler {
             request.display_name.unwrap_or_default().into(),
             request.first_name.unwrap_or_default().into(),
             request.last_name.unwrap_or_default().into(),
+            request.avatar.unwrap_or_default().into(),
             now.naive_utc().into(),
             uuid.into(),
         ];
@@ -408,6 +410,9 @@ impl BackendHandler for SqlBackendHandler {
         }
         if let Some(last_name) = request.last_name {
             values.push((Users::LastName, last_name.into()));
+        }
+        if let Some(avatar) = request.avatar {
+            values.push((Users::Avatar, avatar.into()));
         }
         if values.is_empty() {
             return Ok(());

--- a/server/src/infra/graphql/query.rs
+++ b/server/src/infra/graphql/query.rs
@@ -217,6 +217,10 @@ impl<Handler: BackendHandler + Sync> User<Handler> {
         &self.user.last_name
     }
 
+    fn avatar(&self) -> String {
+        (&self.user.avatar).into()
+    }
+
     fn creation_date(&self) -> chrono::DateTime<chrono::Utc> {
         self.user.creation_date
     }

--- a/server/src/infra/ldap_handler.rs
+++ b/server/src/infra/ldap_handler.rs
@@ -170,6 +170,13 @@ fn get_user_attribute(
         "mail" => vec![user.email.clone().into_bytes()],
         "givenname" => vec![user.first_name.clone().into_bytes()],
         "sn" => vec![user.last_name.clone().into_bytes()],
+        "jpegphoto" => {
+            let bytes = user.avatar.clone().into_bytes();
+            if bytes.is_empty() {
+                return Ok(None);
+            }
+            vec![bytes]
+        }
         "memberof" => groups
             .into_iter()
             .flatten()
@@ -238,6 +245,7 @@ const ALL_USER_ATTRIBUTE_KEYS: &[&str] = &[
     "givenname",
     "sn",
     "cn",
+    "jpegPhoto",
     "createtimestamp",
 ];
 
@@ -1481,6 +1489,7 @@ mod tests {
                 "cn",
                 "createTimestamp",
                 "entryUuid",
+                "jpegPhoto",
             ],
         );
         assert_eq!(
@@ -1567,6 +1576,10 @@ mod tests {
                         LdapPartialAttribute {
                             atype: "entryUuid".to_string(),
                             vals: vec![b"04ac75e0-2900-3e21-926c-2f732c26b3fc".to_vec()]
+                        },
+                        LdapPartialAttribute {
+                            atype: "jpegPhoto".to_string(),
+                            vals: vec![JpegPhoto::for_tests().into_bytes()]
                         },
                     ],
                 }),
@@ -2067,6 +2080,7 @@ mod tests {
                     display_name: "Bôb Böbberson".to_string(),
                     first_name: "Bôb".to_string(),
                     last_name: "Böbberson".to_string(),
+                    avatar: JpegPhoto::for_tests(),
                     ..Default::default()
                 },
                 groups: None,
@@ -2124,6 +2138,10 @@ mod tests {
                     LdapPartialAttribute {
                         atype: "cn".to_string(),
                         vals: vec!["Bôb Böbberson".to_string().into_bytes()],
+                    },
+                    LdapPartialAttribute {
+                        atype: "jpegPhoto".to_string(),
+                        vals: vec![JpegPhoto::for_tests().into_bytes()],
                     },
                     LdapPartialAttribute {
                         atype: "createtimestamp".to_string(),

--- a/server/src/infra/ldap_handler.rs
+++ b/server/src/infra/ldap_handler.rs
@@ -1459,6 +1459,7 @@ mod tests {
                         display_name: "Jimminy Cricket".to_string(),
                         first_name: "Jim".to_string(),
                         last_name: "Cricket".to_string(),
+                        avatar: JpegPhoto::for_tests(),
                         uuid: uuid!("04ac75e0-2900-3e21-926c-2f732c26b3fc"),
                         creation_date: Utc.ymd(2014, 7, 8).and_hms(9, 10, 11),
                     },

--- a/server/src/infra/ldap_server.rs
+++ b/server/src/infra/ldap_server.rs
@@ -9,7 +9,7 @@ use actix_rt::net::TcpStream;
 use actix_server::ServerBuilder;
 use actix_service::{fn_service, ServiceFactoryExt};
 use anyhow::{Context, Result};
-use ldap3_server::{proto::LdapMsg, LdapCodec};
+use ldap3_proto::{proto::LdapMsg, LdapCodec};
 use tokio_rustls::TlsAcceptor as RustlsTlsAcceptor;
 use tokio_util::codec::{FramedRead, FramedWrite};
 use tracing::{debug, error, info, instrument};


### PR DESCRIPTION
Does most of the heavy lifting required for #171 . With this, users can update their avatar in LLDAP and it is served in LDAP as `jpegPhoto` attribute.

Note that this only supports JPEG, not PNG.

This does not include support for the migration tool.