### PR TITLE
server: fix handling of present filters

### DIFF
--- a/server/src/domain/ldap/group.rs
+++ b/server/src/domain/ldap/group.rs
@@ -163,7 +163,7 @@ fn convert_group_filter(
             if field == "objectclass"
                 || field == "dn"
                 || field == "distinguishedname"
-                || ALL_GROUP_ATTRIBUTE_KEYS.contains(&field.as_str())
+                || map_group_field(field).is_some()
             {
                 Ok(GroupRequestFilter::And(vec![]))
             } else {

--- a/server/src/domain/ldap/user.rs
+++ b/server/src/domain/ldap/user.rs
@@ -167,7 +167,7 @@ fn convert_user_filter(ldap_info: &LdapInfo, filter: &LdapFilter) -> LdapResult<
             if field == "objectclass"
                 || field == "dn"
                 || field == "distinguishedname"
-                || ALL_USER_ATTRIBUTE_KEYS.contains(&field.as_str())
+                || map_user_field(field).is_some()
             {
                 Ok(UserRequestFilter::And(vec![]))
             } else {


### PR DESCRIPTION
If the filter name was not in the list of attributes to return, it wouldn't be counted as a valid attribute, meaning that the aliases of attributes were not recognized.

Fixes #351