### PR TITLE
docker: add tzdata package, to support TZ env variable

### DIFF
--- a/.github/workflows/Dockerfile.ci.alpine
+++ b/.github/workflows/Dockerfile.ci.alpine
@@ -86,7 +86,7 @@ RUN set -eux; \
 # verify that the binary works
 	gosu --version; \
 	gosu nobody true
-RUN apk add --no-cache tini ca-certificates bash && \
+RUN apk add --no-cache tini ca-certificates bash tzdata && \
     addgroup -g $GID $USER && \
     adduser \
     --disabled-password \

--- a/.github/workflows/Dockerfile.ci.debian
+++ b/.github/workflows/Dockerfile.ci.debian
@@ -58,7 +58,7 @@ ENV UID=1000
 ENV GID=1000
 ENV USER=lldap
 RUN apt update && \
-    apt install -y --no-install-recommends tini openssl ca-certificates gosu && \
+    apt install -y --no-install-recommends tini openssl ca-certificates gosu tzdata && \
     apt clean && \
     rm -rf /var/lib/apt/lists/* && \
     groupadd -g $GID $USER && useradd --system -m -g $USER --uid $UID $USER && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,7 +82,7 @@ COPY --from=builder /app/target/release/lldap /app/target/release/migration-tool
 COPY docker-entrypoint.sh lldap_config.docker_template.toml ./
 
 RUN set -x \
-    && apk add --no-cache bash \
+    && apk add --no-cache bash tzdata \
     && for file in $(cat app/static/libraries.txt); do wget -P app/static "$file"; done \
     && for file in $(cat app/static/fonts/fonts.txt); do wget -P app/static/fonts "$file"; done \
     && chmod a+r -R .

--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ contents are loaded into the respective configuration parameters. Note that
 Example for docker compose:
 * You can use either the `:latest` tag image or `:stable` as used in this example.
 * `:latest` tag image contains recently pushed code or feature tests, in which some instability can be expected.
-* If `UID` and `GID` no defined LLDAP will use default `UID` and `GID` number `1000`
+* If `UID` and `GID` no defined LLDAP will use default `UID` and `GID` number `1000`.
+* If no `TZ` is set, default `UTC` timezone will be used.
 
 
 ```yaml
@@ -125,6 +126,7 @@ services:
     environment:
       - UID=####
       - GID=####
+      - TZ=####/####
       - LLDAP_JWT_SECRET=REPLACE_WITH_RANDOM
       - LLDAP_LDAP_USER_PASS=REPLACE_WITH_PASSWORD
       - LLDAP_LDAP_BASE_DN=dc=example,dc=com


### PR DESCRIPTION
As PR title says, it will add `tzdata` package to the final docker image. Thanks to that, it will be easy to set timezone inside of the container, via `TZ=` env variable.