### PR TITLE
Update readme to use nodejs 16

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,8 @@ front-end.
 
 To compile the project, you'll need:
 
-* npm, curl: `sudo apt install curl npm`
+* nodejs 16: [nodesource nodejs installation guide](https://github.com/nodesource/distributions)
+* curl: `sudo apt install curl`
 * Rust/Cargo: [rustup.rs](https://rustup.rs/)
 
 Then you can compile the server (and the migration tool if you want):


### PR DESCRIPTION
as many variant of system, and different nodejs out there, define nodejs version to match the CI build.