### PR TITLE
server: make `host` configurable to enable IPv6 support

### DIFF
--- a/lldap_config.docker_template.toml
+++ b/lldap_config.docker_template.toml
@@ -8,11 +8,15 @@
 # verbose=false
 
 ## The host address that the LDAP server will be bound to.
-## To enable IPv6 support, simply switch "host" to "::1":
-#host = "0.0.0.0"
+## To enable IPv6 support, simply switch "ldap_host" to "::1":
+#ldap_host = "0.0.0.0"
 
 ## The port on which to have the LDAP server.
 #ldap_port = 3890
+
+## The host address that the HTTP server will be bound to.
+## To enable IPv6 support, simply switch "api_host" to "::1":
+#api_host = "0.0.0.0"
 
 ## The port on which to have the HTTP server, for user login and
 ## administration.

--- a/lldap_config.docker_template.toml
+++ b/lldap_config.docker_template.toml
@@ -7,6 +7,10 @@
 ## You can set it with the LLDAP_VERBOSE environment variable.
 # verbose=false
 
+## The host address that the LDAP server will be bound to.
+## To enable IPv6 support, simply switch "host" to "::1":
+#host = "0.0.0.0"
+
 ## The port on which to have the LDAP server.
 #ldap_port = 3890
 

--- a/lldap_config.docker_template.toml
+++ b/lldap_config.docker_template.toml
@@ -15,8 +15,8 @@
 #ldap_port = 3890
 
 ## The host address that the HTTP server will be bound to.
-## To enable IPv6 support, simply switch "api_host" to "::1":
-#api_host = "0.0.0.0"
+## To enable IPv6 support, simply switch "http_host" to "::1":
+#http_host = "0.0.0.0"
 
 ## The port on which to have the HTTP server, for user login and
 ## administration.

--- a/lldap_config.docker_template.toml
+++ b/lldap_config.docker_template.toml
@@ -8,14 +8,18 @@
 # verbose=false
 
 ## The host address that the LDAP server will be bound to.
-## To enable IPv6 support, simply switch "ldap_host" to "::1":
+## To enable IPv6 support, simply switch "ldap_host" to "::":
+## To only allow connections from localhost (if you want to restrict to local self-hosted services),
+## change it to "127.0.0.1" ("::1" in case of IPv6)".
 #ldap_host = "0.0.0.0"
 
 ## The port on which to have the LDAP server.
 #ldap_port = 3890
 
 ## The host address that the HTTP server will be bound to.
-## To enable IPv6 support, simply switch "http_host" to "::1":
+## To enable IPv6 support, simply switch "http_host" to "::".
+## To only allow connections from localhost (if you want to restrict to local self-hosted services),
+## change it to "127.0.0.1" ("::1" in case of IPv6)".
 #http_host = "0.0.0.0"
 
 ## The port on which to have the HTTP server, for user login and

--- a/server/src/infra/cli.rs
+++ b/server/src/infra/cli.rs
@@ -63,8 +63,8 @@ pub struct RunOpts {
     pub ldap_port: Option<u16>,
 
     /// Change HTTP API host. Default: "0.0.0.0"
-    #[clap(long, env = "LLDAP_API_HOST")]
-    pub api_host: Option<String>,
+    #[clap(long, env = "LLDAP_HTTP_HOST")]
+    pub http_host: Option<String>,
 
     /// Change HTTP API port. Default: 17170
     #[clap(long, env = "LLDAP_HTTP_PORT")]

--- a/server/src/infra/cli.rs
+++ b/server/src/infra/cli.rs
@@ -54,9 +54,17 @@ pub struct RunOpts {
     #[clap(long, env = "LLDAP_SERVER_KEY_FILE")]
     pub server_key_file: Option<String>,
 
+    /// Change ldap host. Default: "0.0.0.0"
+    #[clap(long, env = "LLDAP_LDAP_HOST")]
+    pub ldap_host: Option<String>,
+
     /// Change ldap port. Default: 3890
     #[clap(long, env = "LLDAP_LDAP_PORT")]
     pub ldap_port: Option<u16>,
+
+    /// Change HTTP API host. Default: "0.0.0.0"
+    #[clap(long, env = "LLDAP_API_HOST")]
+    pub api_host: Option<String>,
 
     /// Change HTTP API port. Default: 17170
     #[clap(long, env = "LLDAP_HTTP_PORT")]

--- a/server/src/infra/configuration.rs
+++ b/server/src/infra/configuration.rs
@@ -64,10 +64,12 @@ impl std::default::Default for LdapsOptions {
 #[derive(Clone, Debug, Deserialize, Serialize, derive_builder::Builder)]
 #[builder(pattern = "owned", build_fn(name = "private_build"))]
 pub struct Configuration {
+    #[builder(default = r#"String::from("0.0.0.0")"#)]
+    pub ldap_host: String,
     #[builder(default = "3890")]
     pub ldap_port: u16,
     #[builder(default = r#"String::from("0.0.0.0")"#)]
-    pub host: String,
+    pub api_host: String,
     #[builder(default = "17170")]
     pub http_port: u16,
     #[builder(default = r#"SecUtf8::from("secretjwtsecret")"#)]

--- a/server/src/infra/configuration.rs
+++ b/server/src/infra/configuration.rs
@@ -66,6 +66,8 @@ impl std::default::Default for LdapsOptions {
 pub struct Configuration {
     #[builder(default = "3890")]
     pub ldap_port: u16,
+    #[builder(default = r#"String::from("0.0.0.0")"#)]
+    pub host: String,
     #[builder(default = "17170")]
     pub http_port: u16,
     #[builder(default = r#"SecUtf8::from("secretjwtsecret")"#)]

--- a/server/src/infra/configuration.rs
+++ b/server/src/infra/configuration.rs
@@ -69,7 +69,7 @@ pub struct Configuration {
     #[builder(default = "3890")]
     pub ldap_port: u16,
     #[builder(default = r#"String::from("0.0.0.0")"#)]
-    pub api_host: String,
+    pub http_host: String,
     #[builder(default = "17170")]
     pub http_port: u16,
     #[builder(default = r#"SecUtf8::from("secretjwtsecret")"#)]

--- a/server/src/infra/ldap_server.rs
+++ b/server/src/infra/ldap_server.rs
@@ -177,7 +177,7 @@ where
 
     info!("Starting the LDAP server on port {}", config.ldap_port);
     let server_builder = server_builder
-        .bind("ldap", (config.host.clone(), config.ldap_port), binder)
+        .bind("ldap", (config.ldap_host.clone(), config.ldap_port), binder)
         .with_context(|| format!("while binding to the port {}", config.ldap_port));
     if config.ldaps_options.enabled {
         let tls_context = (
@@ -214,7 +214,7 @@ where
         server_builder.and_then(|s| {
             s.bind(
                 "ldaps",
-                (config.host.clone(), config.ldaps_options.port),
+                (config.ldap_host.clone(), config.ldaps_options.port),
                 tls_binder,
             )
             .with_context(|| format!("while binding to the port {}", config.ldaps_options.port))

--- a/server/src/infra/ldap_server.rs
+++ b/server/src/infra/ldap_server.rs
@@ -177,7 +177,7 @@ where
 
     info!("Starting the LDAP server on port {}", config.ldap_port);
     let server_builder = server_builder
-        .bind("ldap", ("0.0.0.0", config.ldap_port), binder)
+        .bind("ldap", (config.host.clone(), config.ldap_port), binder)
         .with_context(|| format!("while binding to the port {}", config.ldap_port));
     if config.ldaps_options.enabled {
         let tls_context = (
@@ -212,7 +212,7 @@ where
             config.ldaps_options.port
         );
         server_builder.and_then(|s| {
-            s.bind("ldaps", ("0.0.0.0", config.ldaps_options.port), tls_binder)
+            s.bind("ldaps", (config.host.clone(), config.ldaps_options.port), tls_binder)
                 .with_context(|| format!("while binding to the port {}", config.ldaps_options.port))
         })
     } else {

--- a/server/src/infra/ldap_server.rs
+++ b/server/src/infra/ldap_server.rs
@@ -212,8 +212,12 @@ where
             config.ldaps_options.port
         );
         server_builder.and_then(|s| {
-            s.bind("ldaps", (config.host.clone(), config.ldaps_options.port), tls_binder)
-                .with_context(|| format!("while binding to the port {}", config.ldaps_options.port))
+            s.bind(
+                "ldaps",
+                (config.host.clone(), config.ldaps_options.port),
+                tls_binder,
+            )
+            .with_context(|| format!("while binding to the port {}", config.ldaps_options.port))
         })
     } else {
         server_builder

--- a/server/src/infra/tcp_server.rs
+++ b/server/src/infra/tcp_server.rs
@@ -131,7 +131,7 @@ where
     server_builder
         .bind(
             "http",
-            (config.api_host.clone(), config.http_port),
+            (config.http_host.clone(), config.http_port),
             move || {
                 let backend_handler = backend_handler.clone();
                 let jwt_secret = jwt_secret.clone();

--- a/server/src/infra/tcp_server.rs
+++ b/server/src/infra/tcp_server.rs
@@ -129,7 +129,7 @@ where
     let mail_options = config.smtp_options.clone();
     info!("Starting the API/web server on port {}", config.http_port);
     server_builder
-        .bind("http", ("0.0.0.0", config.http_port), move || {
+        .bind("http", (config.host.clone(), config.http_port), move || {
             let backend_handler = backend_handler.clone();
             let jwt_secret = jwt_secret.clone();
             let jwt_blacklist = jwt_blacklist.clone();

--- a/server/src/infra/tcp_server.rs
+++ b/server/src/infra/tcp_server.rs
@@ -129,30 +129,34 @@ where
     let mail_options = config.smtp_options.clone();
     info!("Starting the API/web server on port {}", config.http_port);
     server_builder
-        .bind("http", (config.host.clone(), config.http_port), move || {
-            let backend_handler = backend_handler.clone();
-            let jwt_secret = jwt_secret.clone();
-            let jwt_blacklist = jwt_blacklist.clone();
-            let server_url = server_url.clone();
-            let mail_options = mail_options.clone();
-            HttpServiceBuilder::new()
-                .finish(map_config(
-                    App::new()
-                        .wrap(tracing_actix_web::TracingLogger::<CustomRootSpanBuilder>::new())
-                        .configure(move |cfg| {
-                            http_config(
-                                cfg,
-                                backend_handler,
-                                jwt_secret,
-                                jwt_blacklist,
-                                server_url,
-                                mail_options,
-                            )
-                        }),
-                    |_| AppConfig::default(),
-                ))
-                .tcp()
-        })
+        .bind(
+            "http",
+            (config.api_host.clone(), config.http_port),
+            move || {
+                let backend_handler = backend_handler.clone();
+                let jwt_secret = jwt_secret.clone();
+                let jwt_blacklist = jwt_blacklist.clone();
+                let server_url = server_url.clone();
+                let mail_options = mail_options.clone();
+                HttpServiceBuilder::new()
+                    .finish(map_config(
+                        App::new()
+                            .wrap(tracing_actix_web::TracingLogger::<CustomRootSpanBuilder>::new())
+                            .configure(move |cfg| {
+                                http_config(
+                                    cfg,
+                                    backend_handler,
+                                    jwt_secret,
+                                    jwt_blacklist,
+                                    server_url,
+                                    mail_options,
+                                )
+                            }),
+                        |_| AppConfig::default(),
+                    ))
+                    .tcp()
+            },
+        )
         .with_context(|| {
             format!(
                 "While bringing up the TCP server with port {}",


### PR DESCRIPTION
Introduce a new configuration variable called `host` to enable IPv6 support.

If by any means, the naming of the variable should be adjusted, or a bool is preferred to toggle this behavior, I am for sure willing to adjust this ;)

Resolves #359