### PR TITLE
Fix version in base dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build image
-FROM rust:alpine3.14 AS chef
+FROM rust:alpine3.16 AS chef
 
 RUN set -x \
     # Add user
@@ -41,7 +41,7 @@ RUN cargo build --release -p lldap -p migration-tool \
     && ./app/build.sh
 
 # Final image
-FROM alpine:3.14
+FROM alpine:3.16
 
 ENV GOSU_VERSION 1.14
 # Fetch gosu from git


### PR DESCRIPTION
This was broken by #382 - sea-orm requires rust 1.65. This version of the rust-alpine container uses 1.66.