### PR TITLE
simplify artifacts download and some other things

### DIFF
--- a/.github/workflows/Dockerfile.ci.alpine
+++ b/.github/workflows/Dockerfile.ci.alpine
@@ -10,8 +10,8 @@ RUN mkdir -p target/
 RUN mkdir -p /lldap/app
 
 RUN if [ "${TARGETPLATFORM}" = "linux/amd64" ]; then \
-    mv bin/amd64-bin/lldap target/lldap && \
-    mv bin/amd64-bin/migration-tool target/migration-tool && \
+    mv bin/amd64-lldap-bin/lldap target/lldap && \
+    mv bin/amd64-migration-tool-bin/migration-tool target/migration-tool && \
     chmod +x target/lldap && \
     chmod +x target/migration-tool && \
     ls -la target/ . && \
@@ -19,8 +19,8 @@ RUN if [ "${TARGETPLATFORM}" = "linux/amd64" ]; then \
     ; fi
 
 RUN if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then \
-    mv bin/aarch64-bin/lldap target/lldap && \
-    mv bin/aarch64-bin/migration-tool target/migration-tool && \
+    mv bin/aarch64-lldap-bin/lldap target/lldap && \
+    mv bin/aarch64-migration-tool-bin/migration-tool target/migration-tool && \
     chmod +x target/lldap && \
     chmod +x target/migration-tool && \
     ls -la target/ . && \
@@ -28,8 +28,8 @@ RUN if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then \
     ; fi
 
 RUN if [ "${TARGETPLATFORM}" = "linux/arm/v7" ]; then \
-    mv bin/armhf-bin/lldap target/lldap && \
-    mv bin/armhf-bin/migration-tool target/migration-tool && \
+    mv bin/armhf-lldap-bin/lldap target/lldap && \
+    mv bin/armhf-migration-tool-bin/migration-tool target/migration-tool && \
     chmod +x target/lldap && \
     chmod +x target/migration-tool && \
     ls -la target/ . && \

--- a/.github/workflows/Dockerfile.ci.debian
+++ b/.github/workflows/Dockerfile.ci.debian
@@ -10,8 +10,8 @@ RUN mkdir -p target/
 RUN mkdir -p /lldap/app
 
 RUN if [ "${TARGETPLATFORM}" = "linux/amd64" ]; then \
-    mv bin/amd64-bin/lldap target/lldap && \
-    mv bin/amd64-bin/migration-tool target/migration-tool && \
+    mv bin/amd64-lldap-bin/lldap target/lldap && \
+    mv bin/amd64-migration-tool-bin/migration-tool target/migration-tool && \
     chmod +x target/lldap && \
     chmod +x target/migration-tool && \
     ls -la target/ . && \
@@ -19,8 +19,8 @@ RUN if [ "${TARGETPLATFORM}" = "linux/amd64" ]; then \
     ; fi
 
 RUN if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then \
-    mv bin/aarch64-bin/lldap target/lldap && \
-    mv bin/aarch64-bin/migration-tool target/migration-tool && \
+    mv bin/aarch64-lldap-bin/lldap target/lldap && \
+    mv bin/aarch64-migration-tool-bin/migration-tool target/migration-tool && \
     chmod +x target/lldap && \
     chmod +x target/migration-tool && \
     ls -la target/ . && \
@@ -28,8 +28,8 @@ RUN if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then \
     ; fi
 
 RUN if [ "${TARGETPLATFORM}" = "linux/arm/v7" ]; then \
-    mv bin/armhf-bin/lldap target/lldap && \
-    mv bin/armhf-bin/migration-tool target/migration-tool && \
+    mv bin/armhf-lldap-bin/lldap target/lldap && \
+    mv bin/armhf-migration-tool-bin/migration-tool target/migration-tool && \
     chmod +x target/lldap && \
     chmod +x target/migration-tool && \
     ls -la target/ . && \

--- a/.github/workflows/docker-build-static.yml
+++ b/.github/workflows/docker-build-static.yml
@@ -240,8 +240,8 @@ jobs:
         uses: actions/checkout@v3.3.0
       - name: Download All Artifacts
         uses: actions/download-artifact@v3
-          with:
-            path: bin
+        with:
+          path: bin
 
       - name: Download llap ui artifacts
         uses: actions/download-artifact@v3

--- a/.github/workflows/docker-build-static.yml
+++ b/.github/workflows/docker-build-static.yml
@@ -392,8 +392,32 @@ jobs:
              for file in $(cat app/static/libraries.txt); do wget -P app/static "$file"; done
              for file in $(cat app/static/fonts/fonts.txt); do wget -P app/static/fonts "$file"; done
              chmod a+r -R .
-      - name: compress web
-        run: sudo apt update && sudo apt install -y zip && zip -r web.zip app/
+
+      - name: Setup LLDAP dir for packing
+        run: |
+             mkdir aarch64-lldap
+             mkdir amd64-lldap
+             mkdir armhf-lldap
+             mv bin/aarch64-lldap aarch64-lldap/lldap
+             mv bin/amd64-lldap amd64-lldap/lldap
+             mv bin/armhf-lldap armhf-lldap/lldap
+             mv bin/aarch64-migration-tool aarch64-lldap/migration-tool
+             mv bin/amd64-migration-tool amd64-lldap/migration-tool
+             mv bin/armhf-migration-tool armhf-lldap/migration-tool
+             cp -r app aarch64-lldap/
+             cp -r app amd64-lldap/
+             cp -r app armhf-lldap/
+             ls -alR aarch64-lldap/
+             ls -alR amd64-lldap/
+             ls -alR armhf-lldap/
+
+      - name: Compress
+        run: |
+             sudo apt update
+             sudo apt install -y zip
+             zip -r aarch64-lldap.zip aarch64-lldap/
+             zip -r amd64-lldap.zip amd64-lldap/
+             zip -r armhf-lldap.zip armhf-lldap/
 
 
       - name: Upload artifacts release
@@ -401,12 +425,8 @@ jobs:
         id: create_release
         with:
           allowUpdates: true
-          artifacts:  bin/aarch64-lldap,
-                      bin/amd64-lldap,
-                      bin/armhf-lldap,
-                      bin/aarch64-migration-tool,
-                      bin/amd64-migration-tool,
-                      bin/armhf-migration-tool,
-                      web.zip
+          artifacts:  aarch64-lldap.zip,
+                      amd64-lldap.zip,
+                      armhf-lldap.zip
         env:
          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/docker-build-static.yml
+++ b/.github/workflows/docker-build-static.yml
@@ -89,7 +89,6 @@ jobs:
   build-armhf:
     runs-on: ubuntu-latest
     container:
-#      image: rust:1.65
       image: nitnelave/rust-dev:latest
       env:
         CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER: arm-linux-gnueabihf-gcc
@@ -377,6 +376,8 @@ jobs:
              mv bin/aarch64-migration-tool-bin/migration-tool bin/aarch64-migration-tool
              mv bin/amd64-migration-tool-bin/migration-tool bin/amd64-migration-tool
              mv bin/armhf-migration-tool-bin/migration-tool bin/armhf-migration-tool
+             chmod +x bin/*-lldap
+             chmod +x bin/*-migration-tool
 
       - name: Download llap ui artifacts
         uses: actions/download-artifact@v3
@@ -413,11 +414,9 @@ jobs:
 
       - name: Compress
         run: |
-             sudo apt update
-             sudo apt install -y zip
-             zip -r aarch64-lldap.zip aarch64-lldap/
-             zip -r amd64-lldap.zip amd64-lldap/
-             zip -r armhf-lldap.zip armhf-lldap/
+             tar -czvf -r aarch64-lldap.tar.gz aarch64-lldap/
+             tar -czvf amd64-lldap.tar.gz amd64-lldap/
+             tar -czvf armhf-lldap.tar.gz armhf-lldap/
 
 
       - name: Upload artifacts release
@@ -425,8 +424,8 @@ jobs:
         id: create_release
         with:
           allowUpdates: true
-          artifacts:  aarch64-lldap.zip,
-                      amd64-lldap.zip,
-                      armhf-lldap.zip
+          artifacts:  aarch64-lldap.tar.gz,
+                      amd64-lldap.tar.gz,
+                      armhf-lldap.tar.gz
         env:
          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/docker-build-static.yml
+++ b/.github/workflows/docker-build-static.yml
@@ -414,7 +414,7 @@ jobs:
 
       - name: Compress
         run: |
-             tar -czvf -r aarch64-lldap.tar.gz aarch64-lldap/
+             tar -czvf aarch64-lldap.tar.gz aarch64-lldap/
              tar -czvf amd64-lldap.tar.gz amd64-lldap/
              tar -czvf armhf-lldap.tar.gz armhf-lldap/
 

--- a/.github/workflows/docker-build-static.yml
+++ b/.github/workflows/docker-build-static.yml
@@ -240,44 +240,9 @@ jobs:
         uses: actions/checkout@v3.3.0
       - name: Download All Artifacts
         uses: actions/download-artifact@v3
-          path: bin/
+          with:
+            path: bin
 
-#      - name: Download armhf lldap artifacts
-#        uses: actions/download-artifact@v3
-#        with:
-#          name: armhf-lldap-bin
-#          path: bin/armhf-bin
-#      - name: Download armhf migration-tool artifacts
-#        uses: actions/download-artifact@v3
-#        with:
-#          name: armhf-migration-tool-bin
-#          path: bin/armhf-bin
-#
-#      - name: Download aarch64 lldap artifacts
-#        uses: actions/download-artifact@v3
-#        with:
-#          name: aarch64-lldap-bin
-#          path: bin/aarch64-bin
-#      - name: Download aarch64 migration-tool artifacts
-#        uses: actions/download-artifact@v3
-#        with:
-#          name: aarch64-migration-tool-bin
-#          path: bin/aarch64-bin
-#
-#      - name: Download amd64 lldap artifacts
-#        uses: actions/download-artifact@v3
-#        with:
-#          name: amd64-lldap-bin
-#          path: bin/amd64-bin
-#      - name: Download amd64 migration-tool artifacts
-#        uses: actions/download-artifact@v3
-#        with:
-#          name: amd64-migration-tool-bin
-#          path: bin/amd64-bin
-#
-#      - name: check bin path
-#        run: ls -al bin/
-#
       - name: Download llap ui artifacts
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/docker-build-static.yml
+++ b/.github/workflows/docker-build-static.yml
@@ -22,16 +22,19 @@ env:
 # In total 5 jobs, all the jobs are containerized
 # ---
 
+#######################################################################################
+# GitHub actions randomly timeout when downloading musl-gcc                           #
+# Using lldap dev image based on https://hub.docker.com/_/rust and musl-gcc bundled   #
+# Look into .github/workflows/Dockerfile.dev for development image details            #
+#######################################################################################
+
 # build-ui , create/compile the web
-## Use rustlang/rust:nighlty image
-### Install nodejs from nodesource repo
 ### install wasm
 ### install rollup
 ### run app/build.sh
 ### upload artifacts
 
 # builds-armhf, build-aarch64, build-amd64 create binary for respective arch
-## Use rustlang/rust:nightly image
 ### Add non-native architecture dpkg --add-architecture XXX
 ### Install dev tool gcc g++, etc. per respective arch
 ### Cargo build
@@ -44,30 +47,16 @@ env:
 # build-ui,builds-armhf, build-aarch64, build-amd64 will upload artifacts will be used next job
 # build-docker-image job will fetch artifacts and run Dockerfile.ci then push the image.
 
-# On current https://hub.docker.com/_/rust
-# 1-bullseye, 1.61-bullseye, 1.61.0-bullseye, bullseye, 1, 1.61, 1.61.0, latest
-
-# cache
-## cargo
-## target
+# cache based on Cargo.lock
 
 jobs:
   build-ui:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.65
-      env:
-        CARGO_TERM_COLOR: always
-        RUSTFLAGS: -Ctarget-feature=+crt-static
+      image: nitnelave/rust-dev:latest
     steps:
-      - name: install runtime
-        run: apt update && apt install -y gcc-x86-64-linux-gnu g++-x86-64-linux-gnu libc6-dev ca-certificates
-      - name: setup node repo LTS
-        run: curl -fsSL https://deb.nodesource.com/setup_lts.x | bash -
-      - name: install nodejs
-        run: apt install -y nodejs && npm -g install npm
-      - name: smoke test
-        run: rustc --version
+      - name: Checkout repository
+        uses: actions/checkout@v3.3.0
       - uses: actions/cache@v3
         with:
           path: |
@@ -79,10 +68,10 @@ jobs:
           key: lldap-ui-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             lldap-ui-
-      - name: Checkout repository
-        uses: actions/checkout@v3.3.0
       - name: install rollup nodejs
         run: npm install -g rollup
+      - name: add wasm target
+        run: rustup target add wasm32-unknown-unknown
       - name: install wasm-pack with cargo
         run: cargo install wasm-pack || true
         env:
@@ -100,7 +89,8 @@ jobs:
   build-armhf:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.65
+#      image: rust:1.65
+      image: nitnelave/rust-dev:latest
       env:
         CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER: arm-linux-gnueabihf-gcc
         CARGO_TARGET_ARMV7_UNKNOWN_LINUX_MUSLEABIHF_LINKER: arm-linux-gnueabihf-ld
@@ -112,12 +102,8 @@ jobs:
         run: dpkg --add-architecture armhf
       - name: install runtime
         run: apt update && apt install -y gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf libc6-armhf-cross libc6-dev-armhf-cross tar ca-certificates
-      - name: smoke test
-        run: rustc --version
       - name: add armhf target
         run: rustup target add armv7-unknown-linux-gnueabihf
-      - name: smoke test
-        run: rustc --version
       - name: Checkout repository
         uses: actions/checkout@v3.3.0
       - uses: actions/cache@v3
@@ -150,12 +136,6 @@ jobs:
   build-aarch64:
     runs-on: ubuntu-latest
     container:
-##################################################################################
-# GitHub actions currently timeout when downloading musl-gcc                     #
-# Using lldap dev image based on rust:1.65-slim-bullseye and musl-gcc bundled    #
-# Only for Job build aarch64 and amd64                                           #
-###################################################################################
-      #image: rust:1.65
       image: nitnelave/rust-dev:latest
       env:
         CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: aarch64-linux-musl-gcc
@@ -163,10 +143,6 @@ jobs:
         RUSTFLAGS: -Ctarget-feature=+crt-static
         CARGO_HOME: ${GITHUB_WORKSPACE}/.cargo
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3.3.0
-      - name: smoke test
-        run: rustc --version
       - name: Checkout repository
         uses: actions/checkout@v3.3.0
       - uses: actions/cache@v3
@@ -205,7 +181,6 @@ jobs:
   build-amd64:
     runs-on: ubuntu-latest
     container:
-#      image: rust:1.65
       image: nitnelave/rust-dev:latest
       env:
         CARGO_TERM_COLOR: always
@@ -263,43 +238,46 @@ jobs:
         run: sudo apt update && sudo apt install -y rsync
       - name: fetch repo
         uses: actions/checkout@v3.3.0
+      - name: Download All Artifacts
+        uses: actions/download-artifact@v3
+          path: bin/
 
-      - name: Download armhf lldap artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: armhf-lldap-bin
-          path: bin/armhf-bin
-      - name: Download armhf migration-tool artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: armhf-migration-tool-bin
-          path: bin/armhf-bin
-
-      - name: Download aarch64 lldap artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: aarch64-lldap-bin
-          path: bin/aarch64-bin
-      - name: Download aarch64 migration-tool artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: aarch64-migration-tool-bin
-          path: bin/aarch64-bin
-
-      - name: Download amd64 lldap artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: amd64-lldap-bin
-          path: bin/amd64-bin
-      - name: Download amd64 migration-tool artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: amd64-migration-tool-bin
-          path: bin/amd64-bin
-
-      - name: check bin path
-        run: ls -al bin/
-
+#      - name: Download armhf lldap artifacts
+#        uses: actions/download-artifact@v3
+#        with:
+#          name: armhf-lldap-bin
+#          path: bin/armhf-bin
+#      - name: Download armhf migration-tool artifacts
+#        uses: actions/download-artifact@v3
+#        with:
+#          name: armhf-migration-tool-bin
+#          path: bin/armhf-bin
+#
+#      - name: Download aarch64 lldap artifacts
+#        uses: actions/download-artifact@v3
+#        with:
+#          name: aarch64-lldap-bin
+#          path: bin/aarch64-bin
+#      - name: Download aarch64 migration-tool artifacts
+#        uses: actions/download-artifact@v3
+#        with:
+#          name: aarch64-migration-tool-bin
+#          path: bin/aarch64-bin
+#
+#      - name: Download amd64 lldap artifacts
+#        uses: actions/download-artifact@v3
+#        with:
+#          name: amd64-lldap-bin
+#          path: bin/amd64-bin
+#      - name: Download amd64 migration-tool artifacts
+#        uses: actions/download-artifact@v3
+#        with:
+#          name: amd64-migration-tool-bin
+#          path: bin/amd64-bin
+#
+#      - name: check bin path
+#        run: ls -al bin/
+#
       - name: Download llap ui artifacts
         uses: actions/download-artifact@v3
         with:
@@ -326,7 +304,7 @@ jobs:
             type=semver,pattern={{major}}
             type=sha
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -344,9 +322,9 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-######################
-#### latest build ####
-######################
+########################################
+#### docker image :latest tag build ####
+########################################
       - name: Build and push latest alpine
         if: github.event_name != 'release'
         uses: docker/build-push-action@v3
@@ -371,9 +349,9 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
 
-#######################
-#### release build ####
-#######################
+########################################
+#### docker image :semver tag build ####
+########################################
       - name: Build and push release alpine
         if: github.event_name == 'release'
         uses: docker/build-push-action@v3
@@ -411,52 +389,29 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
           repository: nitnelave/lldap
 
-
+###############################################################
+### Download artifacts, clean up ui, upload to release page ###
+###############################################################
   create-release-artifacts:
      needs: [build-ui,build-armhf,build-aarch64,build-amd64]
      name: Create release artifacts
      if: github.event_name == 'release'
      runs-on: ubuntu-latest
      steps:
-
-      - name: Download armhf lldap artifacts
+      - name: Download All Artifacts
         uses: actions/download-artifact@v3
         with:
-          name: armhf-lldap-bin
-          path: bin/armhf-bin
-      - name: Download armhf migration-tool artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: armhf-migration-tool-bin
-          path: bin/armhf-bin
-      - name: Fix binary name armhf
-        run: mv bin/armhf-bin/lldap bin/armhf-bin/lldap-armhf && mv bin/armhf-bin/migration-tool bin/armhf-bin/migration-tool-armhf
-
-      - name: Download aarch64 lldap artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: aarch64-lldap-bin
-          path: bin/aarch64-bin
-      - name: Download aarch64 migration-tool artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: aarch64-migration-tool-bin
-          path: bin/aarch64-bin
-      - name: Fix binary name aarch64
-        run: mv bin/aarch64-bin/lldap bin/aarch64-bin/lldap-aarch64 && mv bin/aarch64-bin/migration-tool bin/aarch64-bin/migration-tool-aarch64
-
-      - name: Download amd64 lldap artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: amd64-lldap-bin
-          path: bin/amd64-bin
-      - name: Download amd64 migration-tool artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: amd64-migration-tool-bin
-          path: bin/amd64-bin
-      - name: Fix binary name amd64
-        run: mv bin/amd64-bin/lldap bin/amd64-bin/lldap-amd64 && mv bin/amd64-bin/migration-tool bin/amd64-bin/migration-tool-amd64
+          path: bin/
+      - name: Check file
+        run: ls -alR bin/
+      - name: Fixing Filename
+        run: |
+             mv bin/aarch64-lldap-bin/lldap bin/aarch64-lldap
+             mv bin/amd64-lldap-bin/lldap bin/amd64-lldap
+             mv bin/armhf-lldap-bin/lldap bin/armhf-lldap
+             mv bin/aarch64-migration-tool-bin/migration-tool bin/aarch64-migration-tool
+             mv bin/amd64-migration-tool-bin/migration-tool bin/amd64-migration-tool
+             mv bin/armhf-migration-tool-bin/migration-tool bin/armhf-migration-tool
 
       - name: Download llap ui artifacts
         uses: actions/download-artifact@v3
@@ -481,12 +436,12 @@ jobs:
         id: create_release
         with:
           allowUpdates: true
-          artifacts:  bin/armhf-bin/lldap-armhf,
-                      bin/aarch64-bin/lldap-aarch64,
-                      bin/amd64-bin/lldap-amd64,
-                      bin/armhf-bin/migration-tool-armhf,
-                      bin/aarch64-bin/migration-tool-aarch64,
-                      bin/amd64-bin/migration-tool-amd64,
+          artifacts:  bin/aarch64-lldap,
+                      bin/amd64-lldap,
+                      bin/armhf-lldap,
+                      bin/aarch64-migration-tool,
+                      bin/amd64-migration-tool,
+                      bin/armhf-migration-tool,
                       web.zip
         env:
          GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
* Use nitnelave/rust-dev:latest for all job
* simplify artifacts download, no more per arch downloading
* add `rustup target add wasm32-unknown-unknown` on ui build, will this affect anything?
* update actions/cache version
* modify release to all in one compressed