### PR TITLE
add option to use insecure SMTP connection

### DIFF
--- a/lldap_config.docker_template.toml
+++ b/lldap_config.docker_template.toml
@@ -113,7 +113,7 @@ key_file = "/data/private_key"
 #server="smtp.gmail.com"
 ## The SMTP port.
 #port=587
-## How the connection is encrypted, either "TLS" or "STARTTLS".
+## How the connection is encrypted, either "NONE" (no encryption), "TLS" or "STARTTLS".
 #smtp_encryption = "TLS"
 ## The SMTP user, usually your email address.
 #user="sender@gmail.com"

--- a/server/src/infra/cli.rs
+++ b/server/src/infra/cli.rs
@@ -117,6 +117,7 @@ pub struct LdapsOpts {
 clap::arg_enum! {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum SmtpEncryption {
+    NONE,
     TLS,
     STARTTLS,
 }

--- a/server/src/infra/configuration.rs
+++ b/server/src/infra/configuration.rs
@@ -266,6 +266,9 @@ impl ConfigOverrider for SmtpOpts {
         if let Some(password) = &self.smtp_password {
             config.smtp_options.password = SecUtf8::from(password.clone());
         }
+        if let Some(smtp_encryption) = &self.smtp_encryption {
+            config.smtp_options.smtp_encryption = smtp_encryption.clone();
+        }
         if let Some(tls_required) = self.smtp_tls_required {
             config.smtp_options.tls_required = Some(tls_required);
         }


### PR DESCRIPTION
Allows to use SMTP without TLS (useful for internal relays). I also noticed, that `port` is ignored, so I added it as well.