### PR TITLE
server: fix clippy warning

### DIFF
--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1,6 +1,7 @@
 #![recursion_limit = "256"]
 #![forbid(non_ascii_idents)]
-#![allow(clippy::nonstandard_macro_braces)]
+#![allow(clippy::uninlined_format_args)]
+
 pub mod components;
 pub mod infra;
 

--- a/migration-tool/src/main.rs
+++ b/migration-tool/src/main.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::uninlined_format_args)]
+
 use std::collections::HashSet;
 
 use anyhow::{anyhow, Result};

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,6 +1,7 @@
 #![forbid(unsafe_code)]
 #![forbid(non_ascii_idents)]
-#![allow(clippy::nonstandard_macro_braces)]
+// TODO: Remove next line once ubuntu upgrades rustc to >=1.67.1
+#![allow(clippy::uninlined_format_args)]
 
 use std::time::Duration;
 


### PR DESCRIPTION
The clippy::uninlined_format_args warning in 1.67 was downgraded to pedantic in 1.67.1 due to lack of support in rust-analyzer, so we're not updating that one yet.