### PR TITLE
Fix: Change input field to password type in change_password ui

### DIFF
--- a/app/src/components/change_password.rs
+++ b/app/src/components/change_password.rs
@@ -246,6 +246,7 @@ impl Component for ChangePasswordForm {
                     <Field
                       form=&self.form
                       field_name="old_password"
+                      input_type="password"
                       class="form-control"
                       class_invalid="is-invalid has-error"
                       class_valid="has-success"


### PR DESCRIPTION
Change input field type for field old_password from its default "text" to "password"