### PR TITLE
Improve reset email errors

### DIFF
--- a/app/src/components/reset_password_step2.rs
+++ b/app/src/components/reset_password_step2.rs
@@ -1,5 +1,5 @@
 use crate::{
-    components::router::AppRoute,
+    components::router::{AppRoute, NavButton},
     infra::{
         api::HostService,
         common_component::{CommonComponent, CommonComponentParts},
@@ -158,9 +158,17 @@ impl Component for ResetPasswordStep2Form {
             }
             (None, Some(e)) => {
                 return html! {
-                  <div class="alert alert-danger">
-                    {e.to_string() }
-                  </div>
+                  <>
+                    <div class="alert alert-danger">
+                      {e.to_string() }
+                    </div>
+                    <NavButton
+                      classes="btn-link btn"
+                      disabled=self.common.is_task_running()
+                      route=AppRoute::Login>
+                      {"Back"}
+                    </NavButton>
+                  </>
                 }
             }
             _ => (),

--- a/server/src/infra/auth_service.rs
+++ b/server/src/infra/auth_service.rs
@@ -214,11 +214,15 @@ where
     let token = request
         .match_info()
         .get("token")
-        .ok_or_else(|| TcpError::BadRequest("Missing reset token".to_string()))?;
+        .ok_or_else(|| TcpError::BadRequest("Missing reset token".to_owned()))?;
     let user_id = data
         .backend_handler
         .get_user_id_for_password_reset_token(token)
-        .await?;
+        .await
+        .map_err(|e| {
+            debug!("Reset token error: {e:#}");
+            TcpError::NotFoundError("Wrong or expired reset token".to_owned())
+        })?;
     let _ = data
         .backend_handler
         .delete_password_reset_token(token)

--- a/server/src/infra/mail.rs
+++ b/server/src/infra/mail.rs
@@ -65,7 +65,9 @@ compromised. You should reset your password and contact an administrator.
 To reset your password please visit the following URL: {}/reset-password/step2/{}
 
 Please contact an administrator if you did not initiate the process.",
-        username, domain, token
+        username,
+        domain.trim_end_matches('/'),
+        token
     );
     send_email(to, "[LLDAP] Password reset requested", body, options).await
 }

--- a/server/src/infra/tcp_server.rs
+++ b/server/src/infra/tcp_server.rs
@@ -37,6 +37,8 @@ pub enum TcpError {
     BadRequest(String),
     #[error("Internal server error: `{0}`")]
     InternalServerError(String),
+    #[error("Not found: `{0}`")]
+    NotFoundError(String),
     #[error("Unauthorized: `{0}`")]
     UnauthorizedError(String),
 }
@@ -57,6 +59,7 @@ pub(crate) fn error_to_http_response(error: TcpError) -> HttpResponse {
             | DomainError::EntityNotFound(_) => HttpResponse::BadRequest(),
         },
         TcpError::BadRequest(_) => HttpResponse::BadRequest(),
+        TcpError::NotFoundError(_) => HttpResponse::NotFound(),
         TcpError::InternalServerError(_) => HttpResponse::InternalServerError(),
         TcpError::UnauthorizedError(_) => HttpResponse::Unauthorized(),
     }


### PR DESCRIPTION
This makes the configuration more robust to a trailing slash in the domain, and improves the error messages when clicking on a non-existing or expired token.