### PR TITLE
app: get rid of rollup, gzip the wasm

### DIFF
--- a/.github/workflows/Dockerfile.dev
+++ b/.github/workflows/Dockerfile.dev
@@ -6,20 +6,17 @@ ENV PATH="/opt/aarch64-linux-musl-cross/:/opt/aarch64-linux-musl-cross/bin/:/opt
 
 ### Install build deps x86_64
 RUN apt update && \
-    apt install -y --no-install-recommends curl git wget build-essential make perl pkg-config curl tar jq musl-tools && \
+    apt install -y --no-install-recommends curl git wget build-essential make perl pkg-config curl tar jq musl-tools gzip && \
     curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && \
     apt update && \
     apt install -y --no-install-recommends nodejs && \
     apt clean && \
-    rm -rf /var/lib/apt/lists/* && \
-    npm install -g npm && \
-    npm install -g yarn && \
-    npm install -g pnpm
+    rm -rf /var/lib/apt/lists/*
 
 ### Install build deps aarch64 build
 RUN dpkg --add-architecture arm64 && \
     apt update && \
-    apt install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libc6-arm64-cross libc6-dev-arm64-cross && \
+    apt install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libc6-arm64-cross libc6-dev-arm64-cross gzip && \
     apt clean && \
     rm -rf /var/lib/apt/lists/* && \
     rustup target add aarch64-unknown-linux-gnu
@@ -27,7 +24,7 @@ RUN dpkg --add-architecture arm64 && \
 ### armhf deps
 RUN dpkg --add-architecture armhf && \
     apt update && \
-    apt install -y gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf libc6-armhf-cross libc6-dev-armhf-cross && \
+    apt install -y gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf libc6-armhf-cross libc6-dev-armhf-cross gzip && \
     apt clean && \
     rm -rf /var/lib/apt/lists/* && \
     rustup target add armv7-unknown-linux-gnueabihf
@@ -43,6 +40,6 @@ RUN wget -c https://musl.cc/x86_64-linux-musl-cross.tgz && \
 ### Add musl target
 RUN rustup target add x86_64-unknown-linux-musl && \
     rustup target add aarch64-unknown-linux-musl
-    
+
 
 CMD ["bash"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,12 @@ members = [
 
 default-members = ["server"]
 
+[profile.release]
+lto = true
+
+[profile.release.package.lldap_app]
+opt-level = 's'
+
 [patch.crates-io.opaque-ke]
 git = 'https://github.com/nitnelave/opaque-ke/'
 branch = 'zeroize_1.5'

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN set -x \
         --uid 10001 \
         app \
     # Install required packages
-    && apk add npm openssl-dev musl-dev make perl curl
+    && apk add openssl-dev musl-dev make perl curl gzip
 
 USER app
 WORKDIR /app
@@ -19,7 +19,6 @@ WORKDIR /app
 RUN set -x \
     # Install build tools
     && RUSTFLAGS=-Ctarget-feature=-crt-static cargo install wasm-pack cargo-chef \
-    && npm install rollup \
     && rustup target add wasm32-unknown-unknown
 
 # Prepare the dependency list.

--- a/app/build.sh
+++ b/app/build.sh
@@ -6,22 +6,12 @@ then
   >&2 echo '`wasm-pack` not found. Try running `cargo install wasm-pack`'
   exit 1
 fi
-
-wasm-pack build --target web
-
-ROLLUP_BIN=$(which rollup 2>/dev/null)
-if [ -f ../node_modules/rollup/dist/bin/rollup ]
+if ! which gzip > /dev/null 2>&1
 then
-  ROLLUP_BIN=../node_modules/rollup/dist/bin/rollup
-elif [ -f node_modules/rollup/dist/bin/rollup ]
-then
-  ROLLUP_BIN=node_modules/rollup/dist/bin/rollup
-fi
-
-if [ -z "$ROLLUP_BIN" ]
-then
-  >&2 echo '`rollup` not found. Try running `npm install rollup`'
+  >&2 echo '`gzip` not found.'
   exit 1
 fi
 
-$ROLLUP_BIN ./main.js --format iife --file ./pkg/bundle.js --globals bootstrap:bootstrap
+wasm-pack build --target web --release
+
+gzip -9 -f pkg/lldap_app_bg.wasm

--- a/app/index.html
+++ b/app/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="utf-8" />
     <title>LLDAP Administration</title>
-    <script src="/pkg/bundle.js" defer></script>
+    <script src="/static/main.js" type="module" defer></script>
     <link
       href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.1/dist/css/bootstrap.min.css"
       rel="preload stylesheet"

--- a/app/index_local.html
+++ b/app/index_local.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="utf-8" />
     <title>LLDAP Administration</title>
-    <script src="/pkg/bundle.js" defer></script>
+    <script src="/static/main.js" type="module" defer></script>
     <link
       href="/static/bootstrap.min.css"
       rel="preload stylesheet"

--- a/app/src/infra/modal.rs
+++ b/app/src/infra/modal.rs
@@ -1,16 +1,16 @@
 use wasm_bindgen::prelude::*;
 
-#[wasm_bindgen(module = "bootstrap")]
+#[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen]
+    #[wasm_bindgen(js_namespace = bootstrap)]
     pub type Modal;
 
-    #[wasm_bindgen(constructor)]
+    #[wasm_bindgen(constructor, js_namespace = bootstrap)]
     pub fn new(e: web_sys::Element) -> Modal;
 
-    #[wasm_bindgen(method)]
+    #[wasm_bindgen(method, js_namespace = bootstrap)]
     pub fn show(this: &Modal);
 
-    #[wasm_bindgen(method)]
+    #[wasm_bindgen(method, js_namespace = bootstrap)]
     pub fn hide(this: &Modal);
 }

--- a/app/static/main.js
+++ b/app/static/main.js
@@ -1,4 +1,4 @@
-import init, { run_app } from './pkg/lldap_app.js';
+import init, { run_app } from '/pkg/lldap_app.js';
 async function main() {
    await init('/pkg/lldap_app_bg.wasm');
    run_app();


### PR DESCRIPTION
This way we get rid of the npm dependency (it's not needed anyway), and we reduce the file size served (2.6MB -> 700kB)