### PR TITLE
Correctly set permission on `/app` path and `entrypoint`

### DIFF
--- a/.github/workflows/Dockerfile.ci.alpine
+++ b/.github/workflows/Dockerfile.ci.alpine
@@ -98,8 +98,8 @@ RUN apk add --no-cache tini ca-certificates bash tzdata && \
     "$USER" && \
     mkdir -p /data && \
     chown $USER:$USER /data
-COPY --from=lldap --chown=$CONTAINERUSER:$CONTAINERUSER /lldap /app
-COPY --from=lldap --chown=$CONTAINERUSER:$CONTAINERUSER /docker-entrypoint.sh /docker-entrypoint.sh
+COPY --from=lldap --chown=$USER:$USER /lldap /app
+COPY --from=lldap --chown=$USER:$USER /docker-entrypoint.sh /docker-entrypoint.sh
 VOLUME ["/data"]
 WORKDIR /app
 ENTRYPOINT ["tini", "--", "/docker-entrypoint.sh"]


### PR DESCRIPTION
On alpine dockerfile got old `$CONTAINERUSER` rather than $USER, oversighted on last overhaul, and undetected because our `docker-entrypoint.sh` correct this on runtime. Then detected after run without `docker-entrypoint.sh` while supporting https://github.com/nitnelave/lldap/pull/475