### PR TITLE
Fix dex config example

### DIFF
--- a/example_configs/dex_config.yml
+++ b/example_configs/dex_config.yml
@@ -27,6 +27,6 @@ connectors:
         baseDN: ou=groups,dc=example,dc=com
         filter: "(objectClass=groupOfUniqueNames)"
         userMatchers:
-          - userAttr: uid
+          - userAttr: DN
             groupAttr: member
-        nameAttr: displayName
+        nameAttr: cn


### PR DESCRIPTION
As discussed on discord, the usserAttr needs to be the full DN, as the search does not work:
```
❯ ldapsearch -x -H ldap://localhost:3890 -D "cn=admin,ou=people,dc=example,dc=com" -b "ou=groups,dc=example,dc=com" -W "member=bob"
Enter LDAP Password: 
# extended LDIF
#
# LDAPv3
# base <ou=groups,dc=example,dc=com> with scope subtree
# filter: member=bob
# requesting: ALL
#

# search result
search: 2
result: 53 Server is unwilling to perform
text: Unsupported group filter: while parsing a user ID: Missing DN value

# numResponses: 1
```