### PR TITLE
WIP: fix: "Creation date" in user forum is displayed as a date

### DIFF
--- a/app/src/components/user_details_form.rs
+++ b/app/src/components/user_details_form.rs
@@ -104,7 +104,7 @@ impl Component for UserDetailsForm {
             if can_edit(a) {
                 get_custom_attribute_input(a, &self.user.attributes)
             } else {
-                get_custom_attribute_static(a, &self.user.attributes)
+                get_custom_attribute_static(a, &self.user)
             }
         };
         html! {
@@ -185,17 +185,28 @@ fn get_custom_attribute_input(
 
 fn get_custom_attribute_static(
     attribute_schema: &AttributeSchema,
-    user_attributes: &[Attribute],
+    // TODO: accessing only untyped attributes doesn't let us have a NaiveDate
+    user: &User,
 ) -> Html {
-    let values = user_attributes
+    let values = &user
+        .attributes
         .iter()
         .find(|a| a.name == attribute_schema.name)
         .map(|attribute| attribute.value.clone())
         .unwrap_or_default();
-    html! {
-        <StaticValue label={attribute_schema.name.clone()} id={attribute_schema.name.clone()}>
-            {values.into_iter().map(|x| html!{<div>{x}</div>}).collect::<Vec<_>>()}
-        </StaticValue>
+    if attribute_schema.name == "creation_date" {
+        let date = user.creation_date;
+        html! {
+            <StaticValue label="Creation date" id={attribute_schema.name.clone()}>
+                <div>{date.naive_local().date()}</div>
+            </StaticValue>
+        }
+    } else {
+        html! {
+            <StaticValue label={attribute_schema.name.clone()} id={attribute_schema.name.clone()}>
+                {values.into_iter().map(|x| html!{<div>{x}</div>}).collect::<Vec<_>>()}
+            </StaticValue>
+        }
     }
 }
 


### PR DESCRIPTION
Previously, when clicking on user details as an admin, i would see `creation_date` with the complete stringy timestamp.

<img width="1178" height="166" alt="Capture d’écran du 2025-07-02 13-47-51" src="https://github.com/user-attachments/assets/552ce050-0386-4199-a775-fb007f5c282b" />

Now it's displayed as in the user list view:

<img width="1376" height="286" alt="image" src="https://github.com/user-attachments/assets/9c94a08f-9030-4b42-8a27-a41eb0f58281" />

This is my first time working with graphql/wasm/yew, so i'm having doubts about the proper way to do things.

- the `User` type is defined as a type alias to `get_user_details::GetUserDetailsUser` but i have no idea where this is defined??? is that somehow an alias to `lldap_domain::types::User`?
- it seems that `User::attributes` is stringy but i can access `User::creation_date`… for the typed version (i also didn't find a way to reparse an arbitrary Attribute/AttributeValue from the stringy representation
- i don't understand why/how we use the arbitrary `attributes` in this template when `user_table` uses typed attributes… is this because of custom extra attributes? or to simplify form/view logic (if so, it doesn't make it easier to read from the outside)

I would be happy to contribute documentation if i understand something finally. I will open a separate issue about frontend documentation. :smile: 