### PR TITLE
docs: Add more information about building/deploying from source

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,8 @@ advanced guides (scripting, migrations, ...) you can contribute to.
 
 ### Code
 
+**NOTE:** To setup your development environment for building from source, see [docs/development.md](docs/development.md).
+
 If you don't know what to start with, check out the 
 [good first issues](https://github.com/lldap/lldap/labels/good%20first%20issue). 
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ MySQL/MariaDB or PostgreSQL.
 
 It's possible to install lldap from OCI images ([docker](docs/install.md#with-docker)/[podman](docs/install.md#with-podman)), from [Kubernetes](docs/install.md#with-kubernetes), or from [a regular distribution package manager](docs/install.md/#from-a-package-repository) (Archlinux, Debian, CentOS, Fedora, OpenSuse, Ubuntu, FreeBSD).
 
-Building [from source](docs/install.md#from-source) and [cross-compiling](docs/install.md#cross-compilation) to a different hardware architecture is also supported.
+Building [from source](docs/install.md#from-source) is supported; instructions for [cross-compiling](docs/development.md#cross-compilation) to a different hardware architecture are also available.
 
 ## Usage
 
@@ -205,10 +205,14 @@ service that seems definitely incompatible with LLDAP.
 - [Does lldap provide commercial support contracts?](docs/faq.md#does-lldap-provide-commercial-support-contracts)
 - [Can I make a donation to fund development?](docs/faq.md#can-i-make-a-donation-to-fund-development)
 - [Is lldap sustainable? Can we depend on it for our infrastructure?](docs/faq.md#is-lldap-sustainable-can-we-depend-on-it-for-our-infrastructure)
+- [What is `Specified path is not a directory` error in my logs?](docs/faq.md#what-is-specified-path-is-not-a-directory-error-in-my-logs)
+- [What hardware architectures are supported by LLDAP?](docs/faq.md#what-hardware-architectures-are-supported-by-lldap)
 
 ## Contributions
 
 Contributions are welcome! Just fork and open a PR. Or just file a bug.
+
+Further instructions on setting up your development environment and how to compile LLDAP can be found in [docs/development.md](docs/development.md).
 
 We don't have a code of conduct, just be respectful and remember that it's just
 normal people doing this for free on their free time.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,7 +34,11 @@ Data storage:
 * `auth/`: Contains the shared structures needed for authentication, the
   interface between front and back-end. In particular, it contains the OPAQUE
   structures and the JWT format.
-* `app/`: The frontend.
+* `app/`: The frontend compiled to WASM
+  * `*.html` files and the `static/` folder: the static files served to web
+    clients
+  * `queries/`: [GraphQL](https://en.wikipedia.org/wiki/GraphQL) queries to
+    communicate with the backend
   * `src/components`: The elements containing the business and display logic of
     the various pages and their components.
   * `src/infra`: Various tools and utilities.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,77 @@
+# Developing LLDAP
+
+This page contains information about setting up your development environment, and compiling/deploying LLDAP from source.
+
+**NOTE:** LLDAP consists of two executables (the `lldap` backend and the `lldap_app_bg.wasm` WASM frontend) and some static files. The executables need to be compiled separately, and the backend server needs to be aware when to find the assets (WASM frontend + static files) with the `assets_path` configuration option in your `lldap_config.toml`.
+
+## Quickstart
+
+The short version is:
+
+```
+git clone https://github.com/lldap/lldap
+cd lldap
+./app/build.sh
+cargo run -- run
+```
+
+If you feel confused, please read on.
+
+## Dependencies
+
+Working on LLDAP requires:
+
+- the latest stable or nightly [Rust](https://rust-lang.org/) release:
+  - with [rustup](https://rustup.rs/) (recommended)
+  - with your system packages (may be out-of-date and fail to compile)
+- [wasm-pack](https://rustwasm.github.io/wasm-pack/):
+  - with [cargo-binstall](https://github.com/cargo-bins/cargo-binstall) (recommended): `cargo binstall wasm-pack`
+  - with basic cargo: `cargo install wasm-pack`
+- `curl` and `gzip`: any version from your system should do the trick
+
+## Frontend
+
+The frontend code is located in the `app/` folder. To compile the frontend WASM, run the `./app/build.sh` script. You'll need to run this after every front-end change to
+update the WASM package served.
+
+Files and folders contained in `app/` need to be readable by the `lldap` server. The server will look for them in the
+configured `assets_path` folder. By default, it will try to find `./app` which will work if you run the server from
+the project root during development.
+
+## Backend
+
+The backend server (the `lldap` CLI) can be compiled using standard `cargo` commands.
+
+**NOTE:** In release mode, LLDAP uses extensive optimization parameters which will make compilation very slow even on
+decent hardware. Make debug builds during development.
+
+- Running a debug build: `cargo run -- run`
+- Running a release build (slower compilation): `cargo run --release -- run`
+
+## Cross-compilation
+
+To cross-compile LLDAP to a different hardware architecture, it's highly recommended
+to install [`cross`](https://github.com/rust-embedded/cross):
+
+- with [cargo-binstall](https://github.com/cargo-bins/cargo-binstall) (recommended): `cargo binstall cross`
+- from source or from release binaries, see [cross installation instructions](https://github.com/cross-rs/cross?tab=readme-ov-file#installation)
+
+Then you can replace your `cargo` calls with `cross`, specifying the `--target=TRIPPLET` of your choice, where the list of available
+target triplets and their level of support are found [on the official Rust docs](https://doc.rust-lang.org/beta/rustc/platform-support.html).
+
+For example: 
+
+```sh
+./app/build.sh
+cross build --target=armv7-unknown-linux-musleabihf -p lldap --release
+```
+
+**NOTE:** If you are deploying LLDAP to a remote device, don't forget to copy the assets contained in the `app/` directory, too!
+
+## Architecture
+
+For a global overview of the project structure, refer to [architecture.md](architecture.md).
+
+## Deployment
+
+For further deployment considerations, refer to the [From source section of the install docs](./install.md#from-source).

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -8,6 +8,8 @@
 - [Does LLDAP provide commercial support contracts?](#does-lldap-provide-commercial-support-contracts)
 - [Can I make a donation to fund development?](#can-i-make-a-donation-to-fund-development)
 - [Is LLDAP sustainable? Can we depend on it for our infrastructure?](#is-lldap-sustainable-can-we-depend-on-it-for-our-infrastructure)
+- [What is `Specified path is not a directory` error in my logs?](#what-is-specified-path-is-not-a-directory-error-in-my-logs)
+- [What hardware architectures are supported by LLDAP?](#what-hardware-architectures-are-supported-by-lldap)
 
 ## I can't log in!
 
@@ -114,3 +116,25 @@ LLDAP is hobbyist software developed in good will by volunteers. LLDAP is not su
 The project is not too complex and is even kept minimalist on purpose. However, unless you'd like to audit and maintain the codebase in the foreseeable future, it's not recommended to adopt LLDAP for the infrastructure of your big organization.
 
 You are free to use LLDAP for any purpose, as long as you respect the copyleft. However, please do not complain if feature X is not implemented, or if the volunteers are not fixing problems fast enough for your taste. LLDAP is a project born of love and adventure, not a commercial endeavour.
+
+## What is `Specified path is not a directory` error in my logs?
+
+If trying to access the webapp results in `No such file or directory (os error 2)`, and you see in your logs something like this:
+
+```
+2025-07-17T15:12:15.514248067+00:00  ERROR    🚨 [error]: Specified path is not a directory: "./app/pkg" | log.target: "actix_files::files" | log.module_path: "actix_files::files" | log.file: "/home/user/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/actix-files-0.6.6/src/files.rs" | log.line: 103
+2025-07-17T15:12:15.514261840+00:00  ERROR    🚨 [error]: Specified path is not a directory: "./app/static" | log.target: "actix_files::files" | log.module_path: "actix_files::files" | log.file: "/home/user/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/actix-files-0.6.6/src/files.rs" | log.line: 103
+2025-07-17T15:12:15.514266989+00:00  ERROR    🚨 [error]: Specified path is not a directory: "./app/static/fonts" | log.target: "actix_files::files" | log.module_path: "actix_files::files" | log.file: "/home/user/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/actix-files-0.6.6/src/files.rs" | log.line: 103
+```
+
+It means the backend `lldap` server did not find the frontend files to serve. By default, it will look for them in the `app` folder in the current working directory.
+
+If you are running LLDAP from source, you may have executed `cargo run` from a subfolder (such as the `src` directory) instead of the project root, or forgotten to build the frontend first. Follow our [Development documentation](./development.md) to understand how to run LLDAP from source.
+
+If you have installed LLDAP from a release tarball or using a package manager, `lldap` may be trying to look for the assets in the wrong directory. For example, if you installed the `lldap` server to `/usr/local/bin/lldap`, and renamed the `app` directory to `/usr/local/share/lldap`, you need to set `assets_path = "/usr/local/share/lldap"` in your configuration file `lldap_config.toml`.`
+
+## What hardware architectures are supported by LLDAP?
+
+We currently support AMD64, ARM64, and ARM/V7 architectures. We provide official docker images for those architectures.
+
+In theory, LLDAP can be compiled to any hardware architecture supported by its dependencies. You may attempt cross-compilation to more architectures and report on your success. See our [Cross-compilation](./development.md#cross-compilation) docs for more information on this process.

--- a/docs/install.md
+++ b/docs/install.md
@@ -349,62 +349,14 @@ LLDAP configuration file: /usr/local/lldap_server/lldap_config.toml<br>
 
 ### From source
 
-#### Backend
+To compile the project from source, see our [Development docs](./development.md). Once the project is successfully compiled, you may:
 
-To compile the project, you'll need:
+- create a configuration file `lldap_config.toml`, following the docker template `lldap_config.docker_template.toml`
+- create a systemd service, see [example_configs/lldap.service](../example_configs/lldap.service)
 
-- curl and gzip: `sudo apt install curl gzip`
-- Rust/Cargo: [rustup.rs](https://rustup.rs/)
+If your `lldap` binary and assets are not in the same folder, or you run the binary from a different working dir, don't forget to:
 
-Then you can compile the server (and the migration tool if you want):
+- specify the configuration file to use with the `-c` flag: `lldap run -c /etc/lldap.toml`
+- specify where to find the assets using `assets_path` in the configuration file
 
-```shell
-cargo build --release -p lldap -p lldap_migration_tool
-```
-
-The resulting binaries will be in `./target/release/`. Alternatively, you can
-just run `cargo run -- run` to run the server.
-
-#### Frontend
-
-To bring up the server, you'll need to compile the frontend. In addition to
-`cargo`, you'll need WASM-pack, which can be installed by running `cargo install wasm-pack`.
-
-Then you can build the frontend files with
-
-```shell
-./app/build.sh
-```
-
-(you'll need to run this after every front-end change to update the WASM
-package served).
-
-The default config is in `src/infra/configuration.rs`, but you can override it
-by creating an `lldap_config.toml`, setting environment variables or passing
-arguments to `cargo run`. Have a look at the docker template:
-`lldap_config.docker_template.toml`.
-
-You can also install it as a systemd service, see
-[lldap.service](example_configs/lldap.service).
-
-### Cross-compilation
-
-Docker images are provided for AMD64, ARM64 and ARM/V7.
-
-If you want to cross-compile yourself, you can do so by installing
-[`cross`](https://github.com/rust-embedded/cross):
-
-```sh
-cargo install cross
-cross build --target=armv7-unknown-linux-musleabihf -p lldap --release
-./app/build.sh
-```
-
-(Replace `armv7-unknown-linux-musleabihf` with the correct Rust target for your
-device.)
-
-You can then get the compiled server binary in
-`target/armv7-unknown-linux-musleabihf/release/lldap` and the various needed files
-(`index.html`, `main.js`, `pkg` folder) in the `app` folder. Copy them to the
-Raspberry Pi (or other target), with the folder structure maintained (`app`
-files in an `app` folder next to the binary).
+All options can be set either via the TOML configuration, or via environment variables prefixed with `LLDAP_`. For example, setting `LLDAP_assets_path` is equivalent to defining `assets_path` in your configuration file.


### PR DESCRIPTION
This addresses the problem i had in #1220 and more.

I added:

- some more information about `assets_path` and the symptoms when it's wrong
- installation instructions for tools with `cargo-binstall` for faster/smaller installs
- notes about running debug builds instead of release builds during development
- a link to the target triplets supported for cross-compilation
- some FAQ entries (~TODO: update TOC in README~ done)
- ~TODO: Add a direct link to the development docs from the README~ done

Let me know if that sounds good :)