### PR TITLE
ldap: normalize base DN in LdapInfo, reduce memory usage

### DIFF
--- a/crates/ldap/src/core/utils.rs
+++ b/crates/ldap/src/core/utils.rs
@@ -300,6 +300,23 @@ pub struct LdapInfo {
     pub ignored_group_attributes: Vec<AttributeName>,
 }
 
+impl LdapInfo {
+    pub fn new(
+        base_dn: &str,
+        ignored_user_attributes: Vec<AttributeName>,
+        ignored_group_attributes: Vec<AttributeName>,
+    ) -> LdapResult<Self> {
+        let base_dn = parse_distinguished_name(&base_dn.to_ascii_lowercase())?;
+        let base_dn_str = join(base_dn.iter().map(|(k, v)| format!("{k}={v}")), ",");
+        Ok(Self {
+            base_dn,
+            base_dn_str,
+            ignored_user_attributes,
+            ignored_group_attributes,
+        })
+    }
+}
+
 pub fn get_custom_attribute(
     attributes: &[Attribute],
     attribute_name: &AttributeName,
@@ -519,6 +536,16 @@ mod tests {
             parse_distinguished_name(" ou  = people , dc = example , dc =  com ")
                 .expect("parsing failed"),
             parsed_dn
+        );
+    }
+
+    #[test]
+    fn test_whitespace_in_ldap_info() {
+        assert_eq!(
+            LdapInfo::new("   ou=people, dc =example,  dc=com \n", vec![], vec![])
+                .unwrap()
+                .base_dn_str,
+            "ou=people,dc=example,dc=com"
         );
     }
 }

--- a/crates/ldap/src/lib.rs
+++ b/crates/ldap/src/lib.rs
@@ -7,7 +7,7 @@ pub(crate) mod modify;
 pub(crate) mod password;
 pub(crate) mod search;
 
-pub use core::utils::{UserFieldType, map_group_field, map_user_field};
+pub use core::utils::{LdapInfo, UserFieldType, map_group_field, map_user_field};
 pub use handler::LdapHandler;
 
 pub use core::group::get_default_group_object_classes;

--- a/crates/ldap/src/search.rs
+++ b/crates/ldap/src/search.rs
@@ -17,7 +17,7 @@ use lldap_domain::{
     public_schema::PublicSchema,
     types::{Group, UserAndGroups},
 };
-use tracing::{debug, instrument, warn};
+use tracing::{debug, warn};
 
 #[derive(Debug)]
 enum SearchScope {
@@ -396,7 +396,6 @@ async fn do_search_internal(
     })
 }
 
-#[instrument(skip_all, level = "debug")]
 pub async fn do_search(
     backend_handler: &impl UserAndGroupListerBackendHandler,
     ldap_info: &LdapInfo,


### PR DESCRIPTION
By making it a &'static, we can have a single allocation for all the threads/async contexts.

This also normalizes the whitespace from the user input; a trailing \n can cause weird issues with clients