### PR TITLE
example_configs: update SSSD guide

### DIFF
--- a/example_configs/pam/README.md
+++ b/example_configs/pam/README.md
@@ -155,7 +155,7 @@ ldap_group_gid_number = gidNumber
 ldap_group_member = uniqueMember
 ```
 
-SSSD will **refuse** to run if it’s config files have the wrong permissions, so apply the following permissions to the
+SSSD will **refuse** to run if its config files have the wrong permissions, so apply the following permissions to the
 files:
 
 ```bash


### PR DESCRIPTION
Hi,

I found the previous guide wasn't really working, and some configuration options seemed wrong for LLDAP, so I rewrote the guide for RFC2307bis with a few parts from the related issue.