### PR TITLE
server: allow specifying the healthcheck addresses

### DIFF
--- a/lldap_config.docker_template.toml
+++ b/lldap_config.docker_template.toml
@@ -159,3 +159,16 @@ key_seed = "RanD0m STR1ng"
 #cert_file="/data/cert.pem"
 ## Certificate key file.
 #key_file="/data/key.pem"
+
+## Options to configure the healthcheck command.
+## To set these options from environment variables, use the following format
+## (example with http_host): LLDAP_HEALTHCHECK_OPTIONS__HTTP_HOST
+[healthcheck_options]
+## The host address that the healthcheck should verify for the HTTP server.
+## If "http_host" is set to a specific IP address, this must be set to match if the built-in
+## healthcheck command is used.  Note: if this is an IPv6 address, it must be wrapped in [].
+#http_host = "localhost"
+## The host address that the healthcheck should verify for the LDAP server.
+## If "ldap_host" is set to a specific IP address, this must be set to match if the built-in
+## healthcheck command is used.
+#ldap_host = "localhost"

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -174,6 +174,9 @@ pub struct RunOpts {
 
     #[clap(flatten)]
     pub ldaps_opts: LdapsOpts,
+
+    #[clap(flatten)]
+    pub healthcheck_opts: HealthcheckOpts,
 }
 
 #[derive(Debug, Parser, Clone)]
@@ -262,6 +265,18 @@ pub struct ExportGraphQLSchemaOpts {
     /// Output to a file. If not specified, the config is printed to the standard output.
     #[clap(short, long)]
     pub output_file: Option<String>,
+}
+
+#[derive(Debug, Parser, Clone)]
+#[clap(next_help_heading = Some("HEALTHCHECK"))]
+pub struct HealthcheckOpts {
+    /// Change the HTTP Host to test the health of.  Default: "localhost"
+    #[clap(long, env = "LLDAP_HEALTHCHECK_OPTIONS__HTTP_HOST")]
+    pub healthcheck_http_host: Option<String>,
+
+    /// Change the LDAP Host to test the health of.  Default: "localhost"
+    #[clap(long, env = "LLDAP_HEALTHCHECK_OPTIONS__LDAP_HOST")]
+    pub healthcheck_ldap_host: Option<String>,
 }
 
 pub fn init() -> CLIOpts {

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -255,9 +255,18 @@ async fn run_healthcheck(opts: RunOpts) -> Result<()> {
     use tokio::time::timeout;
     let delay = Duration::from_millis(3000);
     let (ldap, ldaps, api) = tokio::join!(
-        timeout(delay, healthcheck::check_ldap(config.ldap_port)),
-        timeout(delay, healthcheck::check_ldaps(&config.ldaps_options)),
-        timeout(delay, healthcheck::check_api(config.http_port)),
+        timeout(
+            delay,
+            healthcheck::check_ldap(&config.healthcheck_options.ldap_host, config.ldap_port)
+        ),
+        timeout(
+            delay,
+            healthcheck::check_ldaps(&config.healthcheck_options.ldap_host, &config.ldaps_options)
+        ),
+        timeout(
+            delay,
+            healthcheck::check_api(&config.healthcheck_options.http_host, config.http_port)
+        ),
     );
 
     let failure = [ldap, ldaps, api]


### PR DESCRIPTION
This change adds two new optional configuration options:
- `ldap_healthcheck_host` to pair with `ldap_host`
- `http_healthcheck_host` to pair with `http_host`

These new options will allow someone to specify a specific address for `ldap_host` and `http_host` and still have functional health checks, as health checks were previously hard-coded to check against `localhost` prior to this change.  These new settings default to `localhost` to preserve the existing behavior.

Fixes #700