### PR TITLE
docs: lldap password in docker install corrected

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -68,7 +68,7 @@ services:
       - LLDAP_JWT_SECRET=REPLACE_WITH_RANDOM
       - LLDAP_KEY_SEED=REPLACE_WITH_RANDOM
       - LLDAP_LDAP_BASE_DN=dc=example,dc=com
-      - LLDAP_LDAP_USER_PASS=adminPas$word
+      - LLDAP_LDAP_USER_PASS=CHANGE_ME # If the password contains '$', escape it (e.g. Pas$$word sets Pas$word)
       # If using LDAPS, set enabled true and configure cert and key path
       # - LLDAP_LDAPS_OPTIONS__ENABLED=true
       # - LLDAP_LDAPS_OPTIONS__CERT_FILE=/path/to/certfile.crt


### PR DESCRIPTION
## Summary

This PR fixes misleading Docker Compose example for `LLDAP_LDAP_USER_PASS` as reported by @garylavayou within #1128

## Description

In the documentation’s Docker Compose example, the environment variable:

```yaml
- LLDAP_LDAP_USER_PASS=adminPas$word
```

is misleading.

Docker Compose treats `$word` as a variable reference, which is **undefined** and thus replaced by an empty string.  
As a result, the actual password becomes `adminPas`, while users will likely attempt to log in with `adminPas$word`, causing authentication failures.

#### What this PR does

This PR updates the example to clarify how to escape `$` in Compose environment variables:

```yaml
- LLDAP_LDAP_USER_PASS=CHANGE_ME # If the password contains '$', escape it (e.g. Pas$$word sets Pas$word)
```

This avoids confusion and improves the onboarding experience for new users setting up LLDAP via Docker Compose.

#### Why this matters

New users following the documentation exactly will encounter login errors when trying to use `adminPas$word`.  
By explicitly showing how to escape `$`, the documentation becomes clearer and reduces setup friction.