### PR TITLE
docs: Rename 'mail_alias' to 'mail-alias' in example config

### DIFF
--- a/example_configs/bootstrap/bootstrap.md
+++ b/example_configs/bootstrap/bootstrap.md
@@ -130,7 +130,7 @@ Fields description:
     "isVisible": true
   },
   {
-    "name": "mail_alias",
+    "name": "mail-alias",
     "attributeType": "STRING",
     "isEditable": false,
     "isList": true,


### PR DESCRIPTION
The example included an invalid character `_` for the attribute `name`

This resulted in:

```
Cannot create attribute with invalid name. Valid characters: a-z, A-Z, 0-9, and dash (-). Invalid chars found: _
```

This fixes the example by using a `-`.