### PR TITLE
fix(bootstrap): set shopt nullglob

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -605,6 +605,7 @@ main() {
   local group_schema_files=()
 
   local file=''
+  shopt -s nullglob
   [[ -d "$USER_CONFIGS_DIR" ]] && for file in "${USER_CONFIGS_DIR}"/*.json; do
     user_config_files+=("$file")
   done
@@ -617,6 +618,7 @@ main() {
   [[ -d "$GROUP_SCHEMAS_DIR" ]] && for file in "${GROUP_SCHEMAS_DIR}"/*.json; do
     group_schema_files+=("$file")
   done
+  shopt -u nullglob
 
   if ! check_configs_validity "${group_config_files[@]}" "${user_config_files[@]}" "${group_schema_files[@]}" "${user_schema_files[@]}"; then
     exit 1


### PR DESCRIPTION
Set the `nullglob` option in the bootstrap script to handle cases where
no files match a glob pattern.

This prevents the following error when the folder exists without json
files:

```
/bootstrap/group-configs/*.json: jq: error: Could not open file /bootstrap/group-configs/*.json: No such file or directory
```
