### PR TITLE
fix grafana example

### DIFF
--- a/example_configs/grafana_ldap_config.toml
+++ b/example_configs/grafana_ldap_config.toml
@@ -41,7 +41,14 @@ name = "displayName"
 surname = "sn"
 username = "uid"
 
-# If you want to map your ldap groups to grafana's groups, see: https://grafana.com/docs/grafana/latest/auth/ldap/#group-mappings
+# If you want to map your ldap groups to grafana's groups, configure the group query:
+# https://grafana.com/docs/grafana/latest/setup-grafana/configure-access/configure-authentication/ldap/#posix-schema
+# group_search_filter = "(&(objectClass=groupOfUniqueNames)(uniqueMember=%s))"
+# group_search_base_dns = ["ou=groups,dc=example,dc=com"]
+# group_search_filter_user_attribute = "uid"
+#
+# Then configure the groups:
+# https://grafana.com/docs/grafana/latest/setup-grafana/configure-access/configure-authentication/ldap/#group-mappings
 # As a quick example, here is how you would map lldap's admin group to grafana's admin
 # [[servers.group_mappings]]
 # group_dn = "cn=lldap_admin,ou=groups,dc=example,dc=org"


### PR DESCRIPTION
Improves the Grafana example to include a working configuration for the group query.

Without it, grafana fails with:

```
"User does not belong in any of the specified LDAP groups" username=rcambrj groups=[]
```

<details>
<summary>full log:</summary>

```
logger=ldap t=2025-12-04T14:59:50.862046203Z level=warn msg="User does not belong in any of the specified LDAP groups" username=rcambrj groups=[]
logger=authn.service t=2025-12-04T14:59:50.873015158Z level=info msg="Failed to authenticate request" client=auth.client.form error="[password-auth.failed] failed to authenticate identity: [password auth.invalid[] invalid password: invalid username or password\n[identity.not-found] no user found: user not found"
logger=context userId=0 orgId=0 uname= t=2025-12-04T14:59:50.87329385Z level=info msg="Request Completed" method=POST path=/login status=401 remote_addr=10.42.1.0 time_ms=1059 duration=1.059800547s size=94 referer=https://[redacted]/login handler=/login status_source=server errorReason=Unauthorized errorMessageID=password-auth.failed error="failed to authenticate identity: [password-auth.invalid[] invalid password: invalid username or password\n[identity.not-found] no user found: user not found"
```

</details>