### PR TITLE
fix(sql-backend-handler): enable lldap_domain "test" feature in dev-deps

### DIFF
--- a/crates/sql-backend-handler/Cargo.toml
+++ b/crates/sql-backend-handler/Cargo.toml
@@ -71,6 +71,10 @@ path = "../domain-model"
 [dependencies.lldap_opaque_handler]
 path = "../opaque-handler"
 
+[dev-dependencies.lldap_domain]
+path = "../domain"
+features = ["test"]
+
 [dev-dependencies.lldap_test_utils]
 path = "../test-utils"
 


### PR DESCRIPTION
## Summary

The `lldap_domain` crate gates `JpegPhoto::for_tests()` and uuid test helpers behind a `test` feature flag. The `sql-backend-handler` dev-dependencies referenced `lldap_domain` without enabling that feature, causing ~12 compilation errors in `sql_user_backend_handler.rs` and `sql_tables.rs` when building the test binary.

This PR adds a `[dev-dependencies.lldap_domain]` entry with `features = ["test"]`, which unblocks `cargo test -p lldap_sql_backend_handler --lib`.

## Test plan

- [ ] Run `cargo check -p lldap_sql_backend_handler --tests` — should succeed with no errors
- [ ] Run `cargo test -p lldap_sql_backend_handler --lib` — test binary now compiles and runs