### PR TITLE
Reintroduce LLDAP_USER_PASSWORD in bootstrap.sh

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -712,9 +712,9 @@ main() {
     redundant_users="$(printf '%s' "$redundant_users" | jq --compact-output --arg id "$id" '. - [$id]')"
 
     if [[ "$password_file" != 'null' ]] && [[ "$password_file" != '""' ]]; then
-      "$LLDAP_SET_PASSWORD_PATH" --base-url "$LLDAP_URL" --token "$TOKEN" --username "$id" --password "$(cat $password_file)"
+      LLDAP_USER_PASSWORD="$(< "$password_file")" "$LLDAP_SET_PASSWORD_PATH" --base-url "$LLDAP_URL" --token "$TOKEN" --username "$id"
     elif [[ "$password" != 'null' ]] && [[ "$password" != '""' ]]; then
-      "$LLDAP_SET_PASSWORD_PATH" --base-url "$LLDAP_URL" --token "$TOKEN" --username "$id" --password "$password"
+      LLDAP_USER_PASSWORD="$password" "$LLDAP_SET_PASSWORD_PATH" --base-url "$LLDAP_URL" --token "$TOKEN" --username "$id"
     fi
 
     # Process custom attributes


### PR DESCRIPTION
Ensure no passwords are leaked via cmdline.

Reverts revert of #1245, where I suspect  `bootstrap.sh` and `lldap_set_password` were of different versions, for the release happened *after* #1228.

Fixes #1432 