### PR TITLE
doc: Add Simple Auth to Gogs example config

### DIFF
--- a/example_configs/README.md
+++ b/example_configs/README.md
@@ -24,6 +24,7 @@ configuration files:
 - [Gerrit](gerrit.md)
 - [Gitea](gitea.md)
 - [GitLab](gitlab.md)
+- [Gogs](gogs.md)
 - [Grafana](grafana_ldap_config.toml)
 - [Grocy](grocy.md)
 - [Harbor](harbor.md)

--- a/example_configs/gogs.md
+++ b/example_configs/gogs.md
@@ -8,7 +8,7 @@ For type, select "LDAP (Simple Auth)".
 Name your authentication source however you'd like. 
 It is up to you to select your security protocol, but the only two compatible options are "LDAPS" and "Unencrypted". 
 As your host, put in the IP or FQDN (if you have DNS).
-As your port, check your configuration. It will generally be 389 or 3890 for unencrypted (once again check your config files), 636 or 6360 for LDAPS (once again check your config files).
+As your port, check your configuration. It will generally be 3890 for unencrypted (once again check your config/docker compose files), and 6360 for LDAPS (once again check your config/docker compose files).
 Your User DN should follow this pattern: `uid=%s,ou=people,<your_base_dn>` (for example, `uid=%s,ou=people,dc=example,dc=com`). Replace `<your_base_dn>` with your actual base DN.
 It is recommended to have your user filter to be `(&(objectClass=person)(uid=%s))`.
 Set username attribute to `uid`, Given Name to `givenName`, surname to `sn`, and email to `mail`

--- a/example_configs/gogs.md
+++ b/example_configs/gogs.md
@@ -8,8 +8,8 @@ For type, select "LDAP (Simple Auth)".
 Name your authentication source however you'd like. 
 It is up to you to select your security protocol, but the only two compatible options are "LDAPS" and "Unencrypted". 
 As your host, put in the IP or FQDN (if you have DNS).
-As your port, it is suggested to look into your config file. It will generally be 389 (unencrypted), 3890 (unencrypted, in default docker compose), 636 (LDAPS), 6360 (LDAPS, in default docker compose).
-Your User DN **has** to be equal to `uid=%s,ou=people,dc=example,dc=com`, except if you changed your Base DN. In that case, modify the two last parts to match it.
+As your port, it is suggested to look into your config or docker compose file. It will generally be 389 (unencrypted), 3890 (unencrypted, in default docker compose), 636 (LDAPS), 6360 (LDAPS, in default docker compose).
+Your User DN **has** to be equal to `uid=%s,ou=people,dc=example,dc=com`, except if you changed your Base DN. In that case, remove the two last parts and add it at the end.
 It is recommended to have your user filter to be `(&(objectClass=person)(uid=%s))`.
 Your username attribute should be `uid`.
 Your Given Name attribute should be `givenName`.

--- a/example_configs/gogs.md
+++ b/example_configs/gogs.md
@@ -8,12 +8,12 @@ For type, select "LDAP (Simple Auth)".
 Name your authentication source however you'd like. 
 It is up to you to select your security protocol, but the only two compatible options are "LDAPS" and "Unencrypted". 
 As your host, put in the IP or FQDN (if you have DNS).
-As your port, check your configuration. It will generally be 389/3890 for unencrypted (once again check you config files), 636/6360 for LDAPS (once again check your config files).
-Your User DN should look like `uid=%s,ou=people,dc=example,dc=com` if you have `dc=example,dc=com`, except if you changed your Base DN. In that case, remove the two last parts and add it at the end.
+As your port, check your configuration. It will generally be 389 or 3890 for unencrypted (once again check your config files), 636 or 6360 for LDAPS (once again check your config files).
+Your User DN should look like `uid=%s,ou=people,dc=example,dc=com` if you have `dc=example,dc=com`, except if you changed your Base DN. In that case, remove `dc=example,dc=com` and add your Base DN at the end.
 It is recommended to have your user filter to be `(&(objectClass=person)(uid=%s))`.
-Your username attribute should be `uid`.
+Set the username attribute to be `uid`.
 Your Given Name attribute should be `givenName`.
-Your surname attribute should be `sn`.
+You should set the surname attribute to be `sn`.
 Your email attribute should be `mail`.
 
 You can (and should if you don't know LDAP) leave the rest empty.

--- a/example_configs/gogs.md
+++ b/example_configs/gogs.md
@@ -1,6 +1,24 @@
 # Gogs LDAP configuration
 
-Gogs can make use of LDAP and therefore lldap.
+### Via Simple Auth (easier)
+
+Go to tha Administration settings, then go to Authentication. There, you have to add an authentication source.
+
+For type, select "LDAP (Simple Auth)".
+Name your authentication source however you'd like. 
+It is up to you to select your security protocol, but the only two compatible options are "LDAPS" and "Unencrypted". 
+As your host, put in the IP or FQDN (if you have DNS).
+As your port, it is suggested to look into your config file. It will generally be something like 389, 3890, 636, 6360.
+Your User DN **has** to be equal to `uid=%s,ou=people,dc=example,dc=com`.
+It is recommended to have your user filter to be `(&(objectClass=person)(uid=%s))`.
+Your username attribute should be `uid`.
+Your Given Name attribute should be `givenName`.
+Your surname attribute should be `sn`.
+Your email attribute should be `mail`.
+
+You can (and should if you don't know LDAP) leave the rest empty.
+
+### Via Bind DN (more complicated)
 
 The following configuration is adapted from the example configuration at [their repository](https://github.com/gogs/gogs/blob/main/conf/auth.d/ldap_bind_dn.conf.example).
 The example is a container configuration - the file should live within `conf/auth.d/some_name.conf`:

--- a/example_configs/gogs.md
+++ b/example_configs/gogs.md
@@ -9,7 +9,7 @@ Name your authentication source however you'd like.
 It is up to you to select your security protocol, but the only two compatible options are "LDAPS" and "Unencrypted". 
 As your host, put in the IP or FQDN (if you have DNS).
 As your port, it is suggested to look into your config file. It will generally be 389 (unencrypted), 3890 (unencrypted, in default docker compose), 636 (LDAPS), 6360 (LDAPS, in default docker compose).
-Your User DN **has** to be equal to `uid=%s,ou=people,dc=example,dc=com`.
+Your User DN **has** to be equal to `uid=%s,ou=people,dc=example,dc=com`, except if you changed your Base DN. In that case, modify the two last parts to match it.
 It is recommended to have your user filter to be `(&(objectClass=person)(uid=%s))`.
 Your username attribute should be `uid`.
 Your Given Name attribute should be `givenName`.

--- a/example_configs/gogs.md
+++ b/example_configs/gogs.md
@@ -8,8 +8,8 @@ For type, select "LDAP (Simple Auth)".
 Name your authentication source however you'd like. 
 It is up to you to select your security protocol, but the only two compatible options are "LDAPS" and "Unencrypted". 
 As your host, put in the IP or FQDN (if you have DNS).
-As your port, it is suggested to look into your config or docker compose file. It will generally be 389 (unencrypted), 3890 (unencrypted, in default docker compose), 636 (LDAPS), 6360 (LDAPS, in default docker compose).
-Your User DN **has** to be equal to `uid=%s,ou=people,dc=example,dc=com`, except if you changed your Base DN. In that case, remove the two last parts and add it at the end.
+As your port, check your configuration. It will generally be 389/3890 for unencrypted (once again check you config files), 636/6360 for LDAPS (once again check your config files).
+Your User DN should look like `uid=%s,ou=people,dc=example,dc=com` if you have `dc=example,dc=com`, except if you changed your Base DN. In that case, remove the two last parts and add it at the end.
 It is recommended to have your user filter to be `(&(objectClass=person)(uid=%s))`.
 Your username attribute should be `uid`.
 Your Given Name attribute should be `givenName`.

--- a/example_configs/gogs.md
+++ b/example_configs/gogs.md
@@ -9,12 +9,9 @@ Name your authentication source however you'd like.
 It is up to you to select your security protocol, but the only two compatible options are "LDAPS" and "Unencrypted". 
 As your host, put in the IP or FQDN (if you have DNS).
 As your port, check your configuration. It will generally be 389 or 3890 for unencrypted (once again check your config files), 636 or 6360 for LDAPS (once again check your config files).
-Your User DN should look like `uid=%s,ou=people,dc=example,dc=com` if you have `dc=example,dc=com`, except if you changed your Base DN. In that case, remove `dc=example,dc=com` and add your Base DN at the end.
+Your User DN should follow this pattern: `uid=%s,ou=people,<your_base_dn>` (for example, `uid=%s,ou=people,dc=example,dc=com`). Replace `<your_base_dn>` with your actual base DN.
 It is recommended to have your user filter to be `(&(objectClass=person)(uid=%s))`.
-Set the username attribute to be `uid`.
-Your Given Name attribute should be `givenName`.
-You should set the surname attribute to be `sn`.
-Your email attribute should be `mail`.
+Set username attribute to `uid`, Given Name to `givenName`, surname to `sn`, and email to `mail`
 
 You can (and should if you don't know LDAP) leave the rest empty.
 

--- a/example_configs/gogs.md
+++ b/example_configs/gogs.md
@@ -1,14 +1,14 @@
 # Gogs LDAP configuration
 
-### Via Simple Auth (easier)
+## Via Simple Auth (easier)
 
-Go to tha Administration settings, then go to Authentication. There, you have to add an authentication source.
+Go to the Administration settings, then go to Authentication. There, you have to add an authentication source.
 
 For type, select "LDAP (Simple Auth)".
 Name your authentication source however you'd like. 
 It is up to you to select your security protocol, but the only two compatible options are "LDAPS" and "Unencrypted". 
 As your host, put in the IP or FQDN (if you have DNS).
-As your port, it is suggested to look into your config file. It will generally be something like 389, 3890, 636, 6360.
+As your port, it is suggested to look into your config file. It will generally be 389 (unencrypted), 3890 (unencrypted, in default docker compose), 636 (LDAPS), 6360 (LDAPS, in default docker compose).
 Your User DN **has** to be equal to `uid=%s,ou=people,dc=example,dc=com`.
 It is recommended to have your user filter to be `(&(objectClass=person)(uid=%s))`.
 Your username attribute should be `uid`.
@@ -18,7 +18,7 @@ Your email attribute should be `mail`.
 
 You can (and should if you don't know LDAP) leave the rest empty.
 
-### Via Bind DN (more complicated)
+## Via Bind DN (more complicated)
 
 The following configuration is adapted from the example configuration at [their repository](https://github.com/gogs/gogs/blob/main/conf/auth.d/ldap_bind_dn.conf.example).
 The example is a container configuration - the file should live within `conf/auth.d/some_name.conf`:


### PR DESCRIPTION
I suggest adding a simpler auth method for Gogs. I tested it on my Docker instance, and it works well.