### PR TITLE
fix(bootstrap): fix user_in_group() exit codes and improve error messages

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -192,12 +192,12 @@ user_in_group() {
 
   if ! group_exists "$group_name"; then
     printf '[WARNING] Group "%s" does not exist\n' "$group_name"
-    return
+    return 1
   fi
 
   if ! user_exists "$user_id"; then
-    printf 'User "%s" is not exists\n' "$user_id"
-    return
+    printf '[WARNING] User "%s" does not exist (cannot verify group membership)\n' "$user_id"
+    return 1
   fi
 
   if [[ "$(get_user_details "$user_id" | jq --raw-output --arg displayName "$group_name" '.data.user.groups | any(.[]; select(.displayName == $displayName))')" == 'true' ]]; then
@@ -716,6 +716,9 @@ main() {
     elif [[ "$password" != 'null' ]] && [[ "$password" != '""' ]]; then
       "$LLDAP_SET_PASSWORD_PATH" --base-url "$LLDAP_URL" --token "$TOKEN" --username "$id" --password "$password"
     fi
+
+    # Brief wait for LLDAP to synchronize user before group assignment
+    sleep 1
 
     # Process custom attributes
     printf -- '--- Processing custom attributes for user %s ---\n' "$id"

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -717,9 +717,6 @@ main() {
       "$LLDAP_SET_PASSWORD_PATH" --base-url "$LLDAP_URL" --token "$TOKEN" --username "$id" --password "$password"
     fi
 
-    # Brief wait for LLDAP to synchronize user before group assignment
-    sleep 1
-
     # Process custom attributes
     printf -- '--- Processing custom attributes for user %s ---\n' "$id"
     local attributes_json


### PR DESCRIPTION
## Description

The `user_in_group()` function used bare `return` statements when preconditions failed (group or user not found). A bare `return` defaults to exit code 0, so callers never received the expected failure signal and silently treated missing groups/users as a successful membership check, causing group assignments to be skipped.

## Changes

- `return` → `return 1` when the group does not exist
- `return` → `return 1` when the user does not exist
- Added `[WARNING]` prefix to the group-not-found message for consistency

