### PR TITLE
Update Alpine release image to 3.22

### DIFF
--- a/.github/workflows/Dockerfile.ci.alpine-base
+++ b/.github/workflows/Dockerfile.ci.alpine-base
@@ -59,7 +59,7 @@ RUN set -x \
     && for file in $(cat /lldap/app/static/fonts/fonts.txt); do wget -P app/static/fonts "$file"; done \
     && chmod a+r -R .
 
-FROM alpine:3.19
+FROM alpine:3.22
 WORKDIR /app
 ENV UID=1000
 ENV GID=1000


### PR DESCRIPTION
Updates the Alpine base image used for release Docker images from 3.19 to 3.22.