### PR TITLE
server: Bind to :: by default

### DIFF
--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -135,7 +135,7 @@ pub struct RunOpts {
     #[clap(long, env = "LLDAP_SERVER_KEY_SEED")]
     pub server_key_seed: Option<String>,
 
-    /// Change ldap host. Default: "0.0.0.0"
+    /// Change ldap host. Default: "::"
     #[clap(long, env = "LLDAP_LDAP_HOST")]
     pub ldap_host: Option<String>,
 
@@ -143,7 +143,7 @@ pub struct RunOpts {
     #[clap(long, env = "LLDAP_LDAP_PORT")]
     pub ldap_port: Option<u16>,
 
-    /// Change HTTP API host. Default: "0.0.0.0"
+    /// Change HTTP API host. Default: "::"
     #[clap(long, env = "LLDAP_HTTP_HOST")]
     pub http_host: Option<String>,
 

--- a/server/src/configuration.rs
+++ b/server/src/configuration.rs
@@ -105,11 +105,11 @@ pub struct HttpUrl(pub Url);
 #[derive(Clone, Deserialize, Serialize, derive_builder::Builder, derive_more::Debug)]
 #[builder(pattern = "owned", build_fn(name = "private_build"))]
 pub struct Configuration {
-    #[builder(default = r#"String::from("0.0.0.0")"#)]
+    #[builder(default = r#"String::from("::")"#)]
     pub ldap_host: String,
     #[builder(default = "3890")]
     pub ldap_port: u16,
-    #[builder(default = r#"String::from("0.0.0.0")"#)]
+    #[builder(default = r#"String::from("::")"#)]
     pub http_host: String,
     #[builder(default = "17170")]
     pub http_port: u16,


### PR DESCRIPTION
Healthcheck connects to `localhost`, which may resolve to either IPv4 or Ipv6 depending on the platform. However, the server was previously bound to 0.0.0.0, limiting it to IPv4-only.

Switching to :: allows the server to listen on both IPv6 and IPv4 when the socket is not restricted with IPV6_V6ONLY, as described in RFC 3493.

This improves cross-platform comaptibility and fixes "cargo test" failures in the healthcheck on FreeBSD.