### PR TITLE
Update udm_identity_end_point.md

### DIFF
--- a/example_configs/udm_identity_end_point.md
+++ b/example_configs/udm_identity_end_point.md
@@ -30,7 +30,7 @@ Unique Identifier Attribute - entryUUID
 - Group Object Filter - objectClass=groupOfUniqueNames 
 
 Member Attribute   
-member 
+uniqueMember 
 
 Validate Attribute   
 enter a user e-mail address who has been added in LLDAP , and click test configuration, test show be successful 


### PR DESCRIPTION
There was a mistake in the documentation about UDM/UnifiOS as explained in the commit description:

Replaced Member by uniqueMember in Member Attribute. Otherwise the groups are not detected, and the rules are not applied.

By the way, I think we could rename UDM_identity_end_point into unifiOS_identity_end_point.md as it is applicable to UnifiOS and not only to the UDM Pro.