### PR TITLE
Fix: "Modify password" fails for users with spaces in their User ID

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2743,6 +2743,7 @@ dependencies = [
  "lldap_auth",
  "lldap_frontend_options",
  "lldap_validation",
+ "percent-encoding",
  "rand 0.8.6",
  "serde",
  "serde_json",

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -24,6 +24,7 @@ rand = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 strum = { workspace = true }
+percent-encoding = "2"
 url-escape = "0.1.1"
 validator = "0.14"
 validator_derive = "0.14"

--- a/app/src/components/app.rs
+++ b/app/src/components/app.rs
@@ -183,6 +183,16 @@ impl App {
         }
     }
 
+    /// Percent-decode a URL path segment into a user ID string.
+    /// Returns `None` if the decoded bytes are not valid UTF-8, so the caller
+    /// can redirect to a safe page rather than silently mangling the ID.
+    fn decode_user_id(raw: &str) -> Option<String> {
+        percent_encoding::percent_decode_str(raw)
+            .decode_utf8()
+            .ok()
+            .map(|s| s.into_owned())
+    }
+
     fn dispatch_route(
         switch: &AppRoute,
         link: &Scope<Self>,
@@ -248,11 +258,17 @@ impl App {
             AppRoute::GroupDetails { group_id } => html! {
                 <GroupDetails group_id={*group_id} is_admin={is_admin} />
             },
-            AppRoute::UserDetails { user_id } => html! {
-                <UserDetails username={user_id.clone()} is_admin={is_admin} />
+            AppRoute::UserDetails { user_id } => match Self::decode_user_id(user_id) {
+                Some(decoded_id) => html! {
+                    <UserDetails username={decoded_id} is_admin={is_admin} />
+                },
+                None => html! { <Redirect to={AppRoute::Login} /> },
             },
-            AppRoute::ChangePassword { user_id } => html! {
-                <ChangePasswordForm username={user_id.clone()} is_admin={is_admin} />
+            AppRoute::ChangePassword { user_id } => match Self::decode_user_id(user_id) {
+                Some(decoded_id) => html! {
+                    <ChangePasswordForm username={decoded_id} is_admin={is_admin} />
+                },
+                None => html! { <Redirect to={AppRoute::Login} /> },
             },
             AppRoute::StartResetPassword => match password_reset_enabled {
                 Some(true) => html! { <ResetPasswordStep1Form /> },


### PR DESCRIPTION
`yew-router 0.16` does not percent-decode URL path parameters. When a user ID contains a space (e.g. `user name`), the browser encodes the URL as `/user/user%20name/password`, and yew-router hands the component `user%20name`as-is, causing the request to fail.

Fix: `Percent-decode` the user_id route parameter in dispatch_route (using `percent_encoding::percent_decode_str`) before passing it to `UserDetails` and `ChangePasswordForm`. This ensures both components always receive the actual stored user ID regardless of URL encoding.